### PR TITLE
feat: Run API server with Gunicorn for improved performance and concurrency

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -43,5 +43,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:5000/health || exit 1
 
-# Run the API server
-CMD ["python", "app/app.py"]
+# Run the API server with Gunicorn (production-ready WSGI server)
+# Bind to 0.0.0.0:5000 to match healthcheck and docker-compose expectations
+# Use 2 workers and 2 threads for light concurrency; adjust as needed
+CMD ["gunicorn", "-w", "2", "--threads", "2", "-b", "0.0.0.0:5000", "app.app:app", "--timeout", "90"]


### PR DESCRIPTION
This pull request updates the way the API server is run in the Docker container to use Gunicorn, a production-ready WSGI server, instead of running the Python script directly. This improves concurrency and aligns the server configuration with best practices for production deployments.

Server deployment improvements:

* Updated the Dockerfile to run the API server using Gunicorn with 2 workers and 2 threads, binding to `0.0.0.0:5000`, and set a 90-second timeout. This replaces the previous approach of running the server with `python app/app.py` and provides a more robust, production-ready setup.