### PR TITLE
ci: tighten npm-audit gate from critical to high

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,11 @@ jobs:
         working-directory: ui
         run: |
           npm ci
-          npm audit --audit-level=critical
+          # Gate on HIGH (not just critical): the react-router CVE wave that
+          # shipped in v3.4.5 (GHSA turbo-stream RCE + 2 XSS) was rated HIGH and
+          # silently passed a critical-only gate. Moderate is intentionally not
+          # gated (current brace-expansion devDep advisory has no clean fix).
+          npm audit --audit-level=high
 
   # ── 7. Docker build verification ──────────────────────────────────────
   docker-build:


### PR DESCRIPTION
## Summary

The react-router CVE wave merged in #76 (turbo-stream RCE `GHSA-49rj-9fvp-4h2h`, two XSS, a DoS, an open-redirect) was rated **HIGH/moderate**, so the existing `npm audit --audit-level=critical` gate (`ci.yml`) never failed CI. Main shipped the vulnerable `ui/package-lock.json` green in v3.4.5. This tightens the gate to **high** so the same class fails at PR time.

Moderate is intentionally left ungated — the only current moderate is a `brace-expansion` devDependency advisory with no clean fix.

## Verification

Post-#76 `npm audit` in `ui/`: **0 high / 0 critical** (1 moderate). So this change is green on current main and only changes future behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)