### PR TITLE
fix(ws): server-driven protocol keep-alive; drop dead text ping/pong

### DIFF
--- a/backend-go/internal/websocket/hub.go
+++ b/backend-go/internal/websocket/hub.go
@@ -9,6 +9,20 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	// writeWait is the deadline for a single write (frame) to the peer.
+	writeWait = 10 * time.Second
+	// pongWait is how long readPump waits for the next read before declaring
+	// the connection dead. Reset on every protocol-level pong.
+	pongWait = 90 * time.Second
+	// pingPeriod is how often writePump sends a protocol-level ping. Must be
+	// shorter than pongWait so a pong always lands before the read deadline.
+	// Browsers answer protocol pings automatically (the JS WebSocket API does
+	// not expose ping/pong), which is what actually keeps the stream alive —
+	// there is no application-level heartbeat.
+	pingPeriod = (pongWait * 9) / 10 // 81s
+)
+
 // Client wraps a single WebSocket connection.
 type Client struct {
 	conn *websocket.Conn
@@ -76,26 +90,48 @@ func (h *Hub) ClientCount() int {
 	return len(h.clients)
 }
 
+// writePump is the SOLE writer on the connection (gorilla/websocket forbids
+// concurrent writes). It drains broadcast messages from c.send and, on a
+// pingPeriod ticker, emits a protocol-level ping to keep the stream alive.
 func (c *Client) writePump() {
+	ticker := time.NewTicker(pingPeriod)
 	defer func() {
+		ticker.Stop()
 		if r := recover(); r != nil {
 			log.Debug().Interface("recover", r).Msg("ws writePump recovered")
 		}
 		c.hub.Unregister(c) // clean up on exit
 	}()
-	for msg := range c.send {
-		if err := c.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-			return
+	for {
+		select {
+		case msg, ok := <-c.send:
+			_ = c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				// Hub closed the channel during Unregister — say goodbye.
+				_ = c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+			if err := c.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+				return
+			}
+		case <-ticker.C:
+			_ = c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
 		}
 	}
 }
 
-// readPump reads pings/pongs and detects disconnects.
+// readPump detects disconnects and refreshes the read deadline on every
+// protocol-level pong (sent automatically by the peer in response to the
+// writePump ping). Any inbound application frames are read and discarded —
+// this stream is server→client only.
 func (c *Client) readPump() {
 	defer c.hub.Unregister(c)
-	_ = c.conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+	_ = c.conn.SetReadDeadline(time.Now().Add(pongWait))
 	c.conn.SetPongHandler(func(string) error {
-		_ = c.conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+		_ = c.conn.SetReadDeadline(time.Now().Add(pongWait))
 		return nil
 	})
 	for {

--- a/docs/api/websocket.md
+++ b/docs/api/websocket.md
@@ -7,7 +7,8 @@ The log stream is delivered over a WebSocket connection. Because browsers cannot
 1. `GET /api/ws-token` (HTTP Basic or JWT) — fetch a single-use token.
 2. Open a WebSocket to `/api/ws/logs?token=<token>` on the same origin as the UI.
 3. Receive log entries as JSON messages.
-4. Send the literal string `ping` periodically to keep the connection alive; the server replies with the literal string `pong`.
+
+The connection is kept alive by the **server**, which sends WebSocket protocol-level ping control frames roughly every 80 s; browsers answer them automatically. No application-level heartbeat is required — clients do not need to send anything after connecting.
 
 ## Step 1 — Fetch a token
 
@@ -32,7 +33,7 @@ wss://<your-host>/api/ws/logs?token=xK9z2...
 
 The `web` service proxies the upgrade to the backend on the internal network. If you are connecting from a script running on the host (and only on the host), you can also reach the backend directly at `ws://127.0.0.1:5001/api/ws/logs?token=...`; the backend port is bound to `127.0.0.1` only.
 
-A second connection using the same token is rejected with close code `4003`.
+The token is single-use, so a second connection attempt with the same token is rejected with **HTTP 401** during the handshake, before the WebSocket upgrade completes (see [Authentication failures](#authentication-failures) below).
 
 ## Step 3 — Receive messages
 
@@ -50,14 +51,18 @@ Each message is a JSON object representing a log entry:
 }
 ```
 
-The literal string `pong` (sent in response to a `ping` keep-alive) is the only non-JSON message.
+Every application message is a JSON log entry — there are no sentinel/text messages to filter out.
 
-## Close codes
+## Authentication failures
 
-| Code | Meaning |
+The token is validated **before** the WebSocket upgrade, so authentication problems surface as ordinary HTTP responses on the handshake request rather than as WebSocket close codes:
+
+| Condition | Response |
 |---|---|
-| `4001` | Token not provided |
-| `4003` | Token invalid, expired, or already used |
+| `token` query parameter missing | `HTTP 401` — `missing token` |
+| token invalid, expired, or already used (single-use) | `HTTP 401` — `invalid or expired token` |
+
+Once the upgrade succeeds, the connection follows standard WebSocket lifecycle close codes (`1000` normal, `1001` going away, `1006` abnormal). The server closes idle connections that stop answering protocol pings after ~90 s.
 
 ## JavaScript example
 
@@ -72,15 +77,12 @@ async function connectLogs() {
   const ws    = new WebSocket(url);
 
   ws.onmessage = (event) => {
-    if (event.data === 'pong') return;
     const log = JSON.parse(event.data);
     console.log(log);
   };
 
-  setInterval(() => {
-    if (ws.readyState === WebSocket.OPEN) ws.send('ping');
-  }, 30_000);
-
+  // No keep-alive code needed: the server sends protocol-level pings and the
+  // browser answers them automatically.
   return ws;
 }
 ```

--- a/ui/src/pages/Logs.tsx
+++ b/ui/src/pages/Logs.tsx
@@ -39,7 +39,6 @@ export function Logs() {
     }
 
     let ws: WebSocket | null = null;
-    let pingInterval: ReturnType<typeof setInterval>;
     let reconnectTimeout: ReturnType<typeof setTimeout>;
     let cancelled = false;
     let retryCount = 0;
@@ -66,13 +65,12 @@ export function Logs() {
         ws.onopen = () => {
           setWsStatus('connected');
           retryCount = 0;
-          pingInterval = setInterval(() => {
-            if (ws?.readyState === WebSocket.OPEN) ws.send('ping');
-          }, 30000);
+          // Keep-alive is server-driven: the backend sends protocol-level
+          // WebSocket pings and the browser answers them automatically. No
+          // application-level heartbeat is needed from the client.
         };
 
         ws.onmessage = (event) => {
-          if (event.data === 'pong') return;
           try {
             const newLog = JSON.parse(event.data);
             setRealtimeLogs(prev => [newLog, ...prev].slice(0, 200));
@@ -81,7 +79,6 @@ export function Logs() {
 
         ws.onclose = () => {
           setWsStatus('disconnected');
-          if (pingInterval) clearInterval(pingInterval);
           if (!cancelled && retryCount < MAX_RETRIES) {
             const delay = Math.min(1000 * Math.pow(2, retryCount), 30000);
             retryCount++;
@@ -107,7 +104,6 @@ export function Logs() {
 
     return () => {
       cancelled = true;
-      if (pingInterval) clearInterval(pingInterval);
       if (reconnectTimeout) clearTimeout(reconnectTimeout);
       if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
         ws.close();


### PR DESCRIPTION
## Problem

The log-stream WebSocket had no working keep-alive, and the heartbeat was mismatched across frontend, backend, and docs:

- **backend** `internal/websocket/hub.go` `writePump` had **no ping ticker** → the server never sent protocol-level pings. Browsers can't send them from JS, so `SetPongHandler` never fired and the 90s read deadline was never reset → **every connection died ~every 90s** and the UI silently reconnected.
- **frontend** `ui/src/pages/Logs.tsx` sent a literal text `ws.send('ping')` every 30s and ignored `=== 'pong'` — but the server discards inbound text frames and never replies `pong`, and the UI ignored `pong` anyway (reconnect is `onclose`-driven). Dead code.
- **docs** `docs/api/websocket.md` documented a literal `ping`→`pong` text heartbeat that doesn't exist, plus close codes `4001`/`4003` that are never emitted (auth failures are HTTP 401 *before* the upgrade in `cmd/server/main.go`).

## Fix (option b — idiomatic gorilla, server-driven)

- `hub.go`: `writePump` is now the sole writer via a `select` over `c.send` and a `pingPeriod` (81s) ticker emitting protocol `PingMessage` frames with a `writeWait` deadline; `readPump` uses the `pongWait` (90s) constant. Browsers answer protocol pings automatically — the stream stays alive with **zero client code**.
- `Logs.tsx`: removed the useless text-ping interval and the `pong` filter.
- `websocket.md`: rewrote the heartbeat section (server-driven protocol ping/pong) and replaced the never-emitted close codes with the real HTTP-401-pre-upgrade behaviour.

## Verification

- `go build ./...`, `go vet`, `go test ./internal/websocket/...` — green.
- `tsc -b && vite build` + `Logs.test.tsx` vitest — green.
- **Live local smoke**: a fresh WS client received its first protocol ping at exactly **81s** and the connection stayed open for **95s** — past the old 90s death point. Pre-fix, the server closes at ~90s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)