### PR TITLE
feat(audit): Audit Log page + wider event coverage; stop hover row movement

### DIFF
--- a/backend-go/internal/handlers/blacklists.go
+++ b/backend-go/internal/handlers/blacklists.go
@@ -200,6 +200,9 @@ func (h *BlacklistHandlers) AddIP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	go propagate(h.db, h.cfg, "ip")
+	if user, ok := r.Context().Value(middleware.CtxUsername).(string); ok {
+		database.Audit(h.db, user, "add_ip_blacklist", ip, item.Description)
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "success", "message": "IP added to blacklist"})
 }
 
@@ -258,6 +261,9 @@ func (h *BlacklistHandlers) AddDomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	go propagate(h.db, h.cfg, "domain")
+	if user, ok := r.Context().Value(middleware.CtxUsername).(string); ok {
+		database.Audit(h.db, user, "add_domain_blacklist", domain, item.Description)
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "success", "message": "Domain added to blacklist"})
 }
 

--- a/backend-go/internal/handlers/settings.go
+++ b/backend-go/internal/handlers/settings.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/config"
 	appcrypto "github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/crypto"
+	"github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/database"
+	"github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/middleware"
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog/log"
 )
@@ -99,6 +101,9 @@ func (h *SettingsHandlers) Update(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	if user, ok := r.Context().Value(middleware.CtxUsername).(string); ok {
+		database.Audit(h.db, user, "update_setting", name, "")
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "success", "message": "Setting updated"})
 }
 
@@ -107,6 +112,13 @@ func (h *SettingsHandlers) BulkUpdate(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
+	}
+	if user, ok := r.Context().Value(middleware.CtxUsername).(string); ok && len(body) > 0 {
+		keys := make([]string, 0, len(body))
+		for k := range body {
+			keys = append(keys, k)
+		}
+		database.Audit(h.db, user, "update_settings", strings.Join(keys, ","), "")
 	}
 	for k, v := range body {
 		// Validate key: max 100 chars, alphanumeric+underscore only (matches DB convention)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -34,6 +34,7 @@ const Blacklists = lazy(() => import('./pages/Blacklists').then(m => ({ default:
 const Logs = lazy(() => import('./pages/Logs').then(m => ({ default: m.Logs })));
 const Settings = lazy(() => import('./pages/Settings').then(m => ({ default: m.Settings })));
 const ThreatIntel = lazy(() => import('./pages/ThreatIntel').then(m => ({ default: m.ThreatIntel })));
+const Audit = lazy(() => import('./pages/Audit').then(m => ({ default: m.Audit })));
 
 class ErrorBoundary extends Component<{ children: React.ReactNode }, { error: Error | null }> {
   constructor(props: { children: React.ReactNode }) {
@@ -171,6 +172,7 @@ function App() {
                   <Route path="blacklists" element={<ErrorBoundary><Blacklists /></ErrorBoundary>} />
                   <Route path="threats" element={<ErrorBoundary><ThreatIntel /></ErrorBoundary>} />
                   <Route path="logs" element={<ErrorBoundary><Logs /></ErrorBoundary>} />
+                  <Route path="audit" element={<ErrorBoundary><Audit /></ErrorBoundary>} />
                   <Route path="settings" element={<ErrorBoundary><Settings /></ErrorBoundary>} />
                   <Route path="*" element={<NotFound />} />
                 </Route>

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Ban, ShieldAlert, List, Settings, Search, Command, LogOut } from 'lucide-react';
+import { LayoutDashboard, Ban, ShieldAlert, List, ScrollText, Settings, Search, Command, LogOut } from 'lucide-react';
 import { api } from '../../lib/api';
 
 type ApiStatus = 'connected' | 'disconnected' | 'checking';
@@ -10,6 +10,7 @@ const navItems = [
   { to: '/blacklists', icon: Ban, label: 'Blacklists' },
   { to: '/threats', icon: ShieldAlert, label: 'Threat Intel' },
   { to: '/logs', icon: List, label: 'Access Logs' },
+  { to: '/audit', icon: ScrollText, label: 'Audit Log' },
   { to: '/settings', icon: Settings, label: 'Settings' },
 ];
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -179,11 +179,12 @@
 
   /* Table row hover slide */
   .row-hover {
-    @apply transition-all duration-150;
+    @apply transition-colors duration-150;
   }
+  /* Highlight rows on hover with colour only — never move/scale data that is
+     being read (no transform). */
   .row-hover:hover {
-    @apply bg-white/[0.02];
-    transform: translateX(2px);
+    @apply bg-white/[0.04];
   }
 
   /* Ambient background glow */

--- a/ui/src/pages/Audit.tsx
+++ b/ui/src/pages/Audit.tsx
@@ -1,0 +1,212 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  ScrollText, RefreshCw, Search, Download, ChevronLeft, ChevronRight,
+  LogIn, LogOut, ShieldAlert, KeyRound, Plus, Trash2, Settings2, Database, RotateCcw,
+} from 'lucide-react';
+import { Card, CardContent } from '../components/ui/card';
+import { IpBadge } from '../components/IpBadge';
+import { api } from '../lib/api';
+import type { AuditEntry, AuditPageData } from '../types';
+
+const PAGE_SIZE = 50;
+
+// Visual treatment per action. Colour only — never used to move the row.
+function actionStyle(action: string): { label: string; cls: string; Icon: typeof LogIn } {
+  const a = action.toLowerCase();
+  if (a === 'login') return { label: 'Login', cls: 'text-emerald-300 bg-emerald-500/10 border-emerald-500/20', Icon: LogIn };
+  if (a === 'login_failed') return { label: 'Login failed', cls: 'text-red-300 bg-red-500/10 border-red-500/25', Icon: ShieldAlert };
+  if (a === 'logout') return { label: 'Logout', cls: 'text-slate-300 bg-white/[0.04] border-white/10', Icon: LogOut };
+  if (a === 'change_password') return { label: 'Password change', cls: 'text-amber-300 bg-amber-500/10 border-amber-500/20', Icon: KeyRound };
+  if (a.startsWith('add_')) return { label: action.replace(/_/g, ' '), cls: 'text-emerald-300 bg-emerald-500/10 border-emerald-500/20', Icon: Plus };
+  if (a.startsWith('delete_') || a.includes('remove')) return { label: action.replace(/_/g, ' '), cls: 'text-orange-300 bg-orange-500/10 border-orange-500/20', Icon: Trash2 };
+  if (a.startsWith('update_set')) return { label: action.replace(/_/g, ' '), cls: 'text-cyan-300 bg-cyan-500/10 border-cyan-500/20', Icon: Settings2 };
+  if (a === 'database_reset') return { label: 'Database reset', cls: 'text-red-300 bg-red-500/10 border-red-500/25', Icon: Database };
+  if (a.includes('config') || a.includes('cache') || a.includes('clear') || a.includes('restore') || a.includes('reload'))
+    return { label: action.replace(/_/g, ' '), cls: 'text-blue-300 bg-blue-500/10 border-blue-500/20', Icon: RotateCcw };
+  return { label: action.replace(/_/g, ' '), cls: 'text-slate-300 bg-white/[0.04] border-white/10', Icon: ScrollText };
+}
+
+function parseUtc(ts: string): Date {
+  // Backend stores `datetime('now')` → "2026-06-04 14:30:00" (UTC, no tz).
+  return new Date(ts.includes('T') ? ts : ts.replace(' ', 'T') + 'Z');
+}
+
+function relative(ts: string): string {
+  const d = parseUtc(ts).getTime();
+  if (Number.isNaN(d)) return ts;
+  const s = Math.max(0, Math.round((Date.now() - d) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}
+
+export function Audit() {
+  const [offset, setOffset] = useState(0);
+  const [search, setSearch] = useState('');
+
+  const { data, isLoading, isFetching, refetch } = useQuery<AuditPageData>({
+    queryKey: ['audit-log', offset],
+    queryFn: () => api.get(`audit-log?limit=${PAGE_SIZE}&offset=${offset}`).then((r) => r.data),
+    refetchInterval: 30_000,
+  });
+
+  const entries: AuditEntry[] = data?.data ?? [];
+  const total = data?.total ?? 0;
+
+  const filtered = useMemo(() => {
+    const t = search.trim().toLowerCase();
+    if (!t) return entries;
+    return entries.filter((e) =>
+      [e.username, e.action, e.target, e.details].some((f) => (f ?? '').toLowerCase().includes(t)),
+    );
+  }, [entries, search]);
+
+  const exportCsv = () => {
+    const rows = [
+      ['timestamp', 'username', 'action', 'target', 'details'],
+      ...filtered.map((e) => [e.timestamp, e.username ?? '', e.action, e.target ?? '', e.details ?? '']),
+    ];
+    const csv = rows
+      .map((r) => r.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(','))
+      .join('\n');
+    const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }));
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `audit-log-${new Date().toISOString().slice(0, 10)}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const from = total === 0 ? 0 : offset + 1;
+  const to = offset + entries.length;
+
+  return (
+    <div className="page-enter space-y-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold flex items-center gap-2">
+            <ScrollText className="w-5 h-5 text-cyan-400" />
+            Audit Log
+          </h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Administrative actions — logins, blacklist and settings changes, maintenance.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => refetch()}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-white/[0.04] hover:bg-white/[0.08] transition-colors btn-press"
+          >
+            <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+          <button
+            onClick={exportCsv}
+            disabled={filtered.length === 0}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-white/[0.04] hover:bg-white/[0.08] transition-colors btn-press disabled:opacity-40 disabled:pointer-events-none"
+          >
+            <Download className="w-4 h-4" />
+            CSV
+          </button>
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Filter this page by user, action, target…"
+          className="w-full pl-9 pr-3 py-2 rounded-lg bg-white/[0.03] border border-white/[0.08] text-sm focus:outline-none focus:border-cyan-500/40 focus:bg-white/[0.05] transition-colors"
+        />
+      </div>
+
+      {/* Table */}
+      <Card>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm text-left">
+              <thead className="text-[10px] text-muted-foreground uppercase tracking-wider bg-white/[0.02] border-b border-white/[0.06]">
+                <tr>
+                  <th className="px-5 py-3 font-medium">Time</th>
+                  <th className="px-5 py-3 font-medium">User</th>
+                  <th className="px-5 py-3 font-medium">Action</th>
+                  <th className="px-5 py-3 font-medium">Target</th>
+                  <th className="px-5 py-3 font-medium">Details</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/[0.04]">
+                {isLoading ? (
+                  <tr><td colSpan={5} className="px-5 py-10 text-center text-muted-foreground">Loading…</td></tr>
+                ) : filtered.length === 0 ? (
+                  <tr><td colSpan={5} className="px-5 py-10 text-center text-muted-foreground">
+                    {search ? 'No entries match the filter.' : 'No audit events recorded yet.'}
+                  </td></tr>
+                ) : (
+                  filtered.map((e) => {
+                    const { label, cls, Icon } = actionStyle(e.action);
+                    const targetIsIp = /^\d{1,3}(\.\d{1,3}){3}/.test(e.target ?? '');
+                    return (
+                      <tr key={e.id} className="row-hover align-top">
+                        <td className="px-5 py-3 whitespace-nowrap">
+                          <span className="text-foreground" title={parseUtc(e.timestamp).toLocaleString()}>
+                            {relative(e.timestamp)}
+                          </span>
+                        </td>
+                        <td className="px-5 py-3 whitespace-nowrap font-mono text-xs text-foreground">
+                          {e.username || <span className="text-muted-foreground">—</span>}
+                        </td>
+                        <td className="px-5 py-3 whitespace-nowrap">
+                          <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md border text-xs font-medium ${cls}`}>
+                            <Icon className="w-3.5 h-3.5" />
+                            {label}
+                          </span>
+                        </td>
+                        <td className="px-5 py-3 font-mono text-xs text-muted-foreground max-w-[22rem] truncate" title={e.target ?? ''}>
+                          {e.target ? (targetIsIp ? <IpBadge ip={e.target} /> : e.target) : <span className="text-muted-foreground/50">—</span>}
+                        </td>
+                        <td className="px-5 py-3 text-xs text-muted-foreground max-w-[24rem] truncate" title={e.details ?? ''}>
+                          {e.details || <span className="text-muted-foreground/50">—</span>}
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">
+          {total === 0 ? 'No entries' : `Showing ${from}–${to} of ${total}`}
+          {search && entries.length !== filtered.length ? ` · ${filtered.length} match filter` : ''}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
+            disabled={offset === 0}
+            className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-white/[0.04] hover:bg-white/[0.08] transition-colors btn-press disabled:opacity-40 disabled:pointer-events-none"
+          >
+            <ChevronLeft className="w-4 h-4" /> Prev
+          </button>
+          <button
+            onClick={() => setOffset((o) => o + PAGE_SIZE)}
+            disabled={to >= total}
+            className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-white/[0.04] hover:bg-white/[0.08] transition-colors btn-press disabled:opacity-40 disabled:pointer-events-none"
+          >
+            Next <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -45,6 +45,22 @@ export interface LogsPageData {
   total?: number;
 }
 
+export interface AuditEntry {
+  id: number;
+  username: string | null;
+  action: string;
+  target: string | null;
+  details: string | null;
+  timestamp: string;
+}
+
+export interface AuditPageData {
+  data?: AuditEntry[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+}
+
 export interface TimelineEntry {
   time: string;
   total: number;


### PR DESCRIPTION
## Summary

The `/api/audit-log` endpoint and `audit_log` table existed but had **no UI** and only logged a handful of actions. This adds the page and broadens coverage.

- **New Audit Log page** (`ui/src/pages/Audit.tsx`) — paginated table (time · user · action · target · details) with per-action colour badges, a page filter, CSV export, and proper empty/loading states. Registered in the router (`/audit`) and the sidebar.
- **Wider backend audit coverage** — added `add_ip_blacklist`, `add_domain_blacklist`, `update_setting`, and `update_settings` (bulk), on top of the existing login / logout / login_failed / change_password / delete_* / database_reset / restore_config / reload_config / clear_cache / clear_logs events.
- **UX rule — no movement on data under the cursor.** `.row-hover` used `transform: translateX(2px)`, so every table row shifted on hover. Replaced with a colour-only highlight (`transition-colors` + background). Applies to Logs, Blacklists, and the new Audit table.

## Verification (live, fresh stack)

Generated events via the API and confirmed they surface in `/api/audit-log`:

```
update_settings | enable_safesearch,cache_size
update_setting  | log_level
add_domain_blacklist | audit-demo.invalid | audit page test
```

`go build ./...` + `go vet` green; `tsc -b && vite build` + the UI test suite green; UI served 200 with the new route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)