### PR TITLE
feat(clients): dedicated Clients page with per-client drill-down

### DIFF
--- a/backend-go/internal/handlers/analytics.go
+++ b/backend-go/internal/handlers/analytics.go
@@ -68,6 +68,7 @@ func (h *AnalyticsHandlers) Register(r chi.Router, authMW func(http.Handler) htt
 	r.With(authMW).Get("/api/status", h.Status)
 	r.With(authMW).Get("/api/traffic/statistics", h.TrafficStats)
 	r.With(authMW).Get("/api/clients/statistics", h.ClientStats)
+	r.With(authMW).Get("/api/clients/{ip}/details", h.ClientDetails)
 	r.With(authMW).Get("/api/domains/statistics", h.DomainStats)
 	r.With(authMW).Get("/api/cache/statistics", h.CacheStats)
 	r.With(authMW).Get("/api/waf/stats", h.WAFStats)
@@ -221,7 +222,10 @@ func parseDuration(s string) time.Duration {
 
 func (h *AnalyticsHandlers) ClientStats(w http.ResponseWriter, r *http.Request) {
 	rows, err := h.db.Query(`
-		SELECT source_ip, COUNT(*) AS requests FROM proxy_logs
+		SELECT source_ip, COUNT(*) AS requests,
+		       SUM(CASE WHEN status LIKE '%DENIED%' OR status LIKE '%403%' OR status LIKE '%BLOCKED%' THEN 1 ELSE 0 END) AS blocked,
+		       MAX(timestamp) AS last_seen
+		FROM proxy_logs
 		WHERE source_ip IS NOT NULL AND source_ip != ''
 		GROUP BY source_ip ORDER BY requests DESC LIMIT 50`)
 	if err != nil {
@@ -232,9 +236,13 @@ func (h *AnalyticsHandlers) ClientStats(w http.ResponseWriter, r *http.Request) 
 	var clients []map[string]any
 	for rows.Next() {
 		var ip string
-		var cnt int
-		rows.Scan(&ip, &cnt) //nolint:errcheck
-		clients = append(clients, map[string]any{"ip_address": ip, "requests": cnt, "status": "Active"})
+		var cnt, blocked int
+		var lastSeen sql.NullString
+		rows.Scan(&ip, &cnt, &blocked, &lastSeen) //nolint:errcheck
+		clients = append(clients, map[string]any{
+			"ip_address": ip, "requests": cnt, "blocked": blocked,
+			"last_seen": lastSeen.String, "status": "Active",
+		})
 	}
 	if clients == nil {
 		clients = []map[string]any{}
@@ -242,6 +250,65 @@ func (h *AnalyticsHandlers) ClientStats(w http.ResponseWriter, r *http.Request) 
 	var total int
 	h.db.QueryRow("SELECT COUNT(DISTINCT source_ip) FROM proxy_logs WHERE source_ip IS NOT NULL AND source_ip != ''").Scan(&total) //nolint:errcheck
 	writeOK(w, map[string]any{"total_clients": total, "clients": clients})
+}
+
+// ClientDetails returns a per-client drill-down for a single source IP:
+// totals, top destinations (with how many were blocked), and the most recent
+// requests. The IP is bound as a query parameter, so it is not an injection
+// vector; isValidCIDR rejects obviously malformed input early.
+func (h *AnalyticsHandlers) ClientDetails(w http.ResponseWriter, r *http.Request) {
+	ip := chi.URLParam(r, "ip")
+	if !isValidCIDR(ip) {
+		writeError(w, http.StatusBadRequest, "invalid IP address")
+		return
+	}
+	const blockedCase = `SUM(CASE WHEN status LIKE '%DENIED%' OR status LIKE '%403%' OR status LIKE '%BLOCKED%' THEN 1 ELSE 0 END)`
+
+	var total, blocked int
+	var firstSeen, lastSeen sql.NullString
+	h.db.QueryRow( //nolint:errcheck
+		`SELECT COUNT(*), `+blockedCase+`, MIN(timestamp), MAX(timestamp) FROM proxy_logs WHERE source_ip = ?`,
+		ip,
+	).Scan(&total, &blocked, &firstSeen, &lastSeen)
+
+	topDomains := []map[string]any{}
+	if dr, err := h.db.Query(
+		`SELECT destination, COUNT(*) AS c, `+blockedCase+` AS b
+		 FROM proxy_logs WHERE source_ip = ? AND destination IS NOT NULL AND destination != ''
+		 GROUP BY destination ORDER BY c DESC LIMIT 10`, ip); err == nil {
+		for dr.Next() {
+			var d string
+			var c, b int
+			dr.Scan(&d, &c, &b) //nolint:errcheck
+			topDomains = append(topDomains, map[string]any{"destination": d, "requests": c, "blocked": b})
+		}
+		dr.Close()
+	}
+
+	recent := []map[string]any{}
+	if rr, err := h.db.Query(
+		`SELECT timestamp, method, destination, status, bytes
+		 FROM proxy_logs WHERE source_ip = ? ORDER BY id DESC LIMIT 20`, ip); err == nil {
+		for rr.Next() {
+			var ts, method, dest, status string
+			var nbytes int64
+			rr.Scan(&ts, &method, &dest, &status, &nbytes) //nolint:errcheck
+			recent = append(recent, map[string]any{
+				"timestamp": ts, "method": method, "destination": dest, "status": status, "bytes": nbytes,
+			})
+		}
+		rr.Close()
+	}
+
+	writeOK(w, map[string]any{
+		"ip_address":     ip,
+		"total_requests": total,
+		"blocked":        blocked,
+		"first_seen":     firstSeen.String,
+		"last_seen":      lastSeen.String,
+		"top_domains":    topDomains,
+		"recent":         recent,
+	})
 }
 
 func (h *AnalyticsHandlers) DomainStats(w http.ResponseWriter, r *http.Request) {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -35,6 +35,7 @@ const Logs = lazy(() => import('./pages/Logs').then(m => ({ default: m.Logs })))
 const Settings = lazy(() => import('./pages/Settings').then(m => ({ default: m.Settings })));
 const ThreatIntel = lazy(() => import('./pages/ThreatIntel').then(m => ({ default: m.ThreatIntel })));
 const Audit = lazy(() => import('./pages/Audit').then(m => ({ default: m.Audit })));
+const Clients = lazy(() => import('./pages/Clients').then(m => ({ default: m.Clients })));
 
 class ErrorBoundary extends Component<{ children: React.ReactNode }, { error: Error | null }> {
   constructor(props: { children: React.ReactNode }) {
@@ -171,6 +172,7 @@ function App() {
                   <Route index element={<ErrorBoundary><Dashboard /></ErrorBoundary>} />
                   <Route path="blacklists" element={<ErrorBoundary><Blacklists /></ErrorBoundary>} />
                   <Route path="threats" element={<ErrorBoundary><ThreatIntel /></ErrorBoundary>} />
+                  <Route path="clients" element={<ErrorBoundary><Clients /></ErrorBoundary>} />
                   <Route path="logs" element={<ErrorBoundary><Logs /></ErrorBoundary>} />
                   <Route path="audit" element={<ErrorBoundary><Audit /></ErrorBoundary>} />
                   <Route path="settings" element={<ErrorBoundary><Settings /></ErrorBoundary>} />

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Ban, ShieldAlert, List, ScrollText, Settings, Search, Command, LogOut } from 'lucide-react';
+import { LayoutDashboard, Ban, ShieldAlert, List, ScrollText, Users, Settings, Search, Command, LogOut } from 'lucide-react';
 import { api } from '../../lib/api';
 
 type ApiStatus = 'connected' | 'disconnected' | 'checking';
 
 const navItems = [
   { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
+  { to: '/clients', icon: Users, label: 'Clients' },
   { to: '/blacklists', icon: Ban, label: 'Blacklists' },
   { to: '/threats', icon: ShieldAlert, label: 'Threat Intel' },
   { to: '/logs', icon: List, label: 'Access Logs' },

--- a/ui/src/pages/Clients.tsx
+++ b/ui/src/pages/Clients.tsx
@@ -1,0 +1,250 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  Users, RefreshCw, Search, X, Ban, Globe, Activity, Clock, ArrowUpDown,
+} from 'lucide-react';
+import { Card, CardContent } from '../components/ui/card';
+import { IpBadge } from '../components/IpBadge';
+import { api } from '../lib/api';
+import type { ClientsData, ClientStat, ClientDetail } from '../types';
+
+function parseUtc(ts: string): Date {
+  return new Date(ts.includes('T') ? ts : ts.replace(' ', 'T') + 'Z');
+}
+function relative(ts: string): string {
+  if (!ts) return '—';
+  const d = parseUtc(ts).getTime();
+  if (Number.isNaN(d)) return ts;
+  const s = Math.max(0, Math.round((Date.now() - d) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}
+function rate(blocked: number, total: number): number {
+  return total > 0 ? Math.round((blocked / total) * 1000) / 10 : 0;
+}
+
+type SortKey = 'requests' | 'blocked' | 'rate';
+
+export function Clients() {
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<SortKey>('requests');
+  const [selectedIp, setSelectedIp] = useState<string | null>(null);
+
+  const { data, isLoading, isFetching, refetch } = useQuery<ClientsData>({
+    queryKey: ['clients', 'statistics'],
+    queryFn: () => api.get('clients/statistics').then((r) => r.data.data),
+    refetchInterval: 30_000,
+  });
+
+  const clients: ClientStat[] = data?.clients ?? [];
+
+  const rows = useMemo(() => {
+    const t = search.trim().toLowerCase();
+    const filtered = t ? clients.filter((c) => c.ip_address.toLowerCase().includes(t)) : clients;
+    const sorted = [...filtered].sort((a, b) => {
+      if (sort === 'blocked') return b.blocked - a.blocked;
+      if (sort === 'rate') return rate(b.blocked, b.requests) - rate(a.blocked, a.requests);
+      return b.requests - a.requests;
+    });
+    return sorted;
+  }, [clients, search, sort]);
+
+  const SortTh = ({ k, label }: { k: SortKey; label: string }) => (
+    <th className="px-5 py-3 font-medium">
+      <button
+        onClick={() => setSort(k)}
+        className={`inline-flex items-center gap-1 hover:text-foreground transition-colors ${sort === k ? 'text-foreground' : ''}`}
+      >
+        {label}
+        <ArrowUpDown className="w-3 h-3 opacity-60" />
+      </button>
+    </th>
+  );
+
+  return (
+    <div className="page-enter space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold flex items-center gap-2">
+            <Users className="w-5 h-5 text-cyan-400" />
+            Clients
+          </h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Source IPs seen by the proxy{typeof data?.total_clients === 'number' ? ` — ${data.total_clients} total` : ''}. Select a row for details.
+          </p>
+        </div>
+        <button
+          onClick={() => refetch()}
+          className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-white/[0.04] hover:bg-white/[0.08] transition-colors btn-press"
+        >
+          <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Filter by IP…"
+          className="w-full pl-9 pr-3 py-2 rounded-lg bg-white/[0.03] border border-white/[0.08] text-sm focus:outline-none focus:border-cyan-500/40 focus:bg-white/[0.05] transition-colors"
+        />
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm text-left">
+              <thead className="text-[10px] text-muted-foreground uppercase tracking-wider bg-white/[0.02] border-b border-white/[0.06]">
+                <tr>
+                  <th className="px-5 py-3 font-medium">Client IP</th>
+                  <SortTh k="requests" label="Requests" />
+                  <SortTh k="blocked" label="Blocked" />
+                  <SortTh k="rate" label="Block rate" />
+                  <th className="px-5 py-3 font-medium">Last seen</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/[0.04]">
+                {isLoading ? (
+                  <tr><td colSpan={5} className="px-5 py-10 text-center text-muted-foreground">Loading…</td></tr>
+                ) : rows.length === 0 ? (
+                  <tr><td colSpan={5} className="px-5 py-10 text-center text-muted-foreground">
+                    {search ? 'No clients match the filter.' : 'No client traffic recorded yet.'}
+                  </td></tr>
+                ) : (
+                  rows.map((c) => {
+                    const br = rate(c.blocked, c.requests);
+                    return (
+                      <tr
+                        key={c.ip_address}
+                        onClick={() => setSelectedIp(c.ip_address)}
+                        className="row-hover cursor-pointer"
+                      >
+                        <td className="px-5 py-3"><IpBadge ip={c.ip_address} /></td>
+                        <td className="px-5 py-3 font-mono tabular-nums">{c.requests.toLocaleString()}</td>
+                        <td className="px-5 py-3 font-mono tabular-nums">
+                          {c.blocked > 0 ? <span className="text-orange-300">{c.blocked.toLocaleString()}</span> : <span className="text-muted-foreground">0</span>}
+                        </td>
+                        <td className="px-5 py-3">
+                          <span className={`font-mono tabular-nums text-xs ${br >= 20 ? 'text-red-300' : br > 0 ? 'text-amber-300' : 'text-muted-foreground'}`}>
+                            {br}%
+                          </span>
+                        </td>
+                        <td className="px-5 py-3 text-xs text-muted-foreground whitespace-nowrap" title={c.last_seen ? parseUtc(c.last_seen).toLocaleString() : ''}>
+                          {relative(c.last_seen)}
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {selectedIp && <ClientDrawer ip={selectedIp} onClose={() => setSelectedIp(null)} />}
+    </div>
+  );
+}
+
+function ClientDrawer({ ip, onClose }: { ip: string; onClose: () => void }) {
+  const { data, isLoading } = useQuery<ClientDetail>({
+    queryKey: ['client-details', ip],
+    queryFn: () => api.get(`clients/${encodeURIComponent(ip)}/details`).then((r) => r.data.data),
+  });
+
+  const Stat = ({ label, value, tone = '' }: { label: string; value: string | number; tone?: string }) => (
+    <div className="rounded-lg bg-white/[0.03] border border-white/[0.06] px-3 py-2.5">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{label}</div>
+      <div className={`text-lg font-semibold tabular-nums ${tone}`}>{value}</div>
+    </div>
+  );
+
+  const br = data ? rate(data.blocked, data.total_requests) : 0;
+
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end" role="dialog" aria-modal="true">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative w-full max-w-md h-full overflow-y-auto bg-[var(--card)] border-l border-white/[0.08] shadow-2xl animate-in">
+        <div className="sticky top-0 z-10 flex items-center justify-between px-5 py-4 border-b border-white/[0.06] bg-[var(--card)]">
+          <div className="flex items-center gap-2">
+            <Activity className="w-4 h-4 text-cyan-400" />
+            <IpBadge ip={ip} />
+          </div>
+          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-white/[0.06] transition-colors" aria-label="Close">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {isLoading || !data ? (
+          <div className="p-8 text-center text-muted-foreground">Loading…</div>
+        ) : (
+          <div className="p-5 space-y-6">
+            <div className="grid grid-cols-2 gap-3">
+              <Stat label="Requests" value={data.total_requests.toLocaleString()} />
+              <Stat label="Blocked" value={data.blocked.toLocaleString()} tone={data.blocked > 0 ? 'text-orange-300' : ''} />
+              <Stat label="Block rate" value={`${br}%`} tone={br >= 20 ? 'text-red-300' : br > 0 ? 'text-amber-300' : ''} />
+              <Stat label="Last seen" value={relative(data.last_seen)} />
+            </div>
+            <div className="text-xs text-muted-foreground flex items-center gap-1.5">
+              <Clock className="w-3.5 h-3.5" />
+              First seen {data.first_seen ? parseUtc(data.first_seen).toLocaleString() : '—'}
+            </div>
+
+            <div>
+              <h3 className="text-xs uppercase tracking-wider text-muted-foreground mb-2 flex items-center gap-1.5">
+                <Globe className="w-3.5 h-3.5" /> Top destinations
+              </h3>
+              {data.top_domains.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No destinations recorded.</p>
+              ) : (
+                <div className="space-y-1">
+                  {data.top_domains.map((d) => (
+                    <div key={d.destination} className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg bg-white/[0.02] hover:bg-white/[0.04] transition-colors">
+                      <span className="font-mono text-xs truncate" title={d.destination}>{d.destination}</span>
+                      <span className="flex items-center gap-2 shrink-0 text-xs tabular-nums">
+                        {d.blocked > 0 && (
+                          <span className="inline-flex items-center gap-1 text-orange-300" title={`${d.blocked} blocked`}>
+                            <Ban className="w-3 h-3" />{d.blocked}
+                          </span>
+                        )}
+                        <span className="text-muted-foreground">{d.requests.toLocaleString()}</span>
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <h3 className="text-xs uppercase tracking-wider text-muted-foreground mb-2">Recent requests</h3>
+              {data.recent.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No recent requests.</p>
+              ) : (
+                <div className="space-y-1">
+                  {data.recent.map((e, i) => {
+                    const blocked = /DENIED|403|BLOCKED/i.test(e.status);
+                    return (
+                      <div key={i} className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/[0.02] text-xs">
+                        <span className="text-muted-foreground w-14 shrink-0" title={parseUtc(e.timestamp).toLocaleString()}>{relative(e.timestamp)}</span>
+                        <span className="font-mono text-[10px] text-muted-foreground w-12 shrink-0">{e.method}</span>
+                        <span className="font-mono truncate flex-1" title={e.destination}>{e.destination}</span>
+                        <span className={`shrink-0 ${blocked ? 'text-orange-300' : 'text-muted-foreground'}`}>{blocked ? 'blocked' : 'ok'}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -61,6 +61,43 @@ export interface AuditPageData {
   offset?: number;
 }
 
+export interface ClientStat {
+  ip_address: string;
+  requests: number;
+  blocked: number;
+  last_seen: string;
+  status: string;
+}
+
+export interface ClientsData {
+  total_clients: number;
+  clients: ClientStat[];
+}
+
+export interface ClientDomain {
+  destination: string;
+  requests: number;
+  blocked: number;
+}
+
+export interface ClientRecent {
+  timestamp: string;
+  method: string;
+  destination: string;
+  status: string;
+  bytes: number;
+}
+
+export interface ClientDetail {
+  ip_address: string;
+  total_requests: number;
+  blocked: number;
+  first_seen: string;
+  last_seen: string;
+  top_domains: ClientDomain[];
+  recent: ClientRecent[];
+}
+
 export interface TimelineEntry {
   time: string;
   total: number;


### PR DESCRIPTION
## Summary

`/api/clients/statistics` returned only a flat top-50 list and was surfaced only as the dashboard's top-10 widget — there was no dedicated Clients view and no way to drill into a single source IP.

- **New Clients page** (`ui/src/pages/Clients.tsx`) — sortable table of source IPs (requests · blocked · block rate · last seen) with an IP filter, and a click-through slide-over **drawer** showing per-client details: totals, top destinations (with blocked counts), and recent requests. Registered at `/clients` and in the sidebar.
- **Backend**: `ClientStats` now also returns `blocked` and `last_seen` per client in a single aggregate query (no N+1). New **`GET /api/clients/{ip}/details`** returns the per-client summary, top destinations, and 20 most-recent requests. The IP is a bound query parameter (not an injection vector) and is validated up front.
- Tables follow the no-movement-on-hover rule established earlier (colour-only highlight; rows are click targets).

## Verification (live)

- `/api/clients/statistics` → clients include `blocked` + `last_seen`
- `/api/clients/127.0.0.1/details` → `total_requests`, `blocked`, `first_seen`/`last_seen`, 7 top destinations, 20 recent requests
- malformed IP (`/api/clients/notanip/details`) → **400**
- `go build`/`go vet` green; `tsc -b && vite build` + UI tests green; UI served 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)