### PR TITLE
feat(settings): live service-status panel + responsive layout; read proxy_port

### DIFF
--- a/backend-go/internal/handlers/analytics.go
+++ b/backend-go/internal/handlers/analytics.go
@@ -98,10 +98,14 @@ func (h *AnalyticsHandlers) Status(w http.ResponseWriter, r *http.Request) {
 	todayStr := time.Now().Format("2006-01-02")
 	h.db.QueryRow("SELECT COUNT(*) FROM proxy_logs WHERE timestamp >= ? AND timestamp < date(?, '+1 day')", todayStr, todayStr).Scan(&todayCount) //nolint:errcheck
 
+	// Read the configured proxy port rather than hard-coding 3128.
+	proxyPort := "3128"
+	h.db.QueryRow("SELECT setting_value FROM settings WHERE setting_name = 'proxy_port'").Scan(&proxyPort) //nolint:errcheck
+
 	writeOK(w, map[string]any{
 		"proxy_status":   proxyStatus,
 		"proxy_host":     h.cfg.ProxyHost,
-		"proxy_port":     "3128",
+		"proxy_port":     proxyPort,
 		"timestamp":      time.Now().Format(time.RFC3339),
 		"version":        config.AppVersion,
 		"requests_count": todayCount,

--- a/ui/src/components/settings/ServiceStatus.tsx
+++ b/ui/src/components/settings/ServiceStatus.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Activity, Server, Tag, Users, ArrowDownUp, Ban, Database } from 'lucide-react';
+import { Card, CardContent } from '../ui/card';
+import { api } from '../../lib/api';
+
+// Unwrap the { status, data } envelope.
+function api_get<T = unknown>(path: string): Promise<T> {
+  return api.get(path).then((r) => r.data.data as T);
+}
+
+interface StatusData {
+  proxy_status?: string;
+  proxy_host?: string;
+  proxy_port?: string;
+  version?: string;
+  requests_count?: number;
+}
+
+function num(n: unknown): string {
+  return typeof n === 'number' ? n.toLocaleString() : '—';
+}
+
+function Tile({ icon: Icon, label, value, tone = '', accent = false }: {
+  icon: typeof Activity; label: string; value: ReactNode; tone?: string; accent?: boolean;
+}) {
+  return (
+    <div className={`rounded-lg border px-3 py-2.5 ${accent ? 'border-cyan-500/20 bg-cyan-500/[0.04]' : 'border-white/[0.06] bg-white/[0.02]'}`}>
+      <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+        <Icon className="w-3 h-3" />
+        {label}
+      </div>
+      <div className={`text-sm font-semibold tabular-nums truncate ${tone}`}>{value}</div>
+    </div>
+  );
+}
+
+export function ServiceStatus() {
+  const opts = { refetchInterval: 15_000, staleTime: 10_000 };
+  const status = useQuery<StatusData>({ queryKey: ['status'], queryFn: () => api_get('status'), ...opts });
+  const summary = useQuery<{ today_blocked?: number }>({ queryKey: ['dash-summary-mini'], queryFn: () => api_get('dashboard/summary'), ...opts });
+  const cache = useQuery<{ hit_rate?: number }>({ queryKey: ['cache-mini'], queryFn: () => api_get('cache/statistics'), ...opts });
+  const clients = useQuery<{ total_clients?: number }>({ queryKey: ['clients-mini'], queryFn: () => api_get('clients/statistics'), ...opts });
+
+  const s = status.data;
+  const running = s?.proxy_status === 'running';
+  const hit = cache.data?.hit_rate;
+  const hitPct = typeof hit === 'number' ? `${(hit <= 1 ? hit * 100 : hit).toFixed(1)}%` : '—';
+
+  return (
+    <Card className="bg-transparent">
+      <CardContent className="p-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-3">
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5">
+            <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+              <Activity className="w-3 h-3" /> Proxy
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className={`relative flex h-2 w-2`}>
+                {running && <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400/70" />}
+                <span className={`relative inline-flex rounded-full h-2 w-2 ${running ? 'bg-emerald-400' : 'bg-red-400'}`} />
+              </span>
+              <span className={`text-sm font-semibold ${running ? 'text-emerald-300' : 'text-red-300'}`}>
+                {status.isLoading ? '…' : running ? 'Running' : 'Offline'}
+              </span>
+            </div>
+          </div>
+
+          <Tile icon={Server} label="Listen" value={<span className="font-mono text-xs">{s?.proxy_host ?? 'proxy'}:{s?.proxy_port ?? '3128'}</span>} />
+          <Tile icon={Tag} label="Version" value={s?.version ? `v${s.version}` : '—'} />
+          <Tile icon={Users} label="Clients" value={num(clients.data?.total_clients)} accent />
+          <Tile icon={ArrowDownUp} label="Requests 24h" value={num(s?.requests_count)} />
+          <Tile icon={Ban} label="Blocked 24h" value={num(summary.data?.today_blocked)} tone={(summary.data?.today_blocked ?? 0) > 0 ? 'text-orange-300' : ''} />
+          <Tile icon={Database} label="Cache hit" value={hitPct} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { ChangePassword } from '../components/settings/ChangePassword';
 import { Maintenance } from '../components/settings/Maintenance';
 import { Presets } from '../components/settings/Presets';
+import { ServiceStatus } from '../components/settings/ServiceStatus';
 import { ClientSetup } from '../components/ClientSetup';
 
 // Validation schema for settings form data
@@ -145,13 +146,18 @@ export function Settings() {
         </button>
       </div>
 
+      {/* Live service status */}
+      <ServiceStatus />
+
       {/* Quick Setup Presets */}
       <Presets
         formData={formData}
         onApply={(values) => setFormData(prev => ({ ...prev, ...values }))}
       />
 
-      <div className="grid gap-6">
+      {/* Setting cards flow into two columns on wide screens to cut scrolling;
+          break-inside-avoid keeps each card whole. */}
+      <div className="columns-1 xl:columns-2 xl:gap-6 [&>*]:mb-6 [&>*]:break-inside-avoid">
         <Card className="bg-transparent">
           <CardHeader>
             <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary

The Settings page showed no service status and was one endless single column.

- **Live ServiceStatus panel** at the top: proxy up/down (with a pulse), listen address (`host:port`), version, distinct clients seen, requests + blocked in the last 24h, and cache hit rate. Sourced from the existing `/api/status`, `/api/dashboard/summary`, `/api/cache/statistics`, `/api/clients/statistics` endpoints; auto-refreshes every 15s.
- **Responsive layout**: setting cards now flow into two columns on wide screens (`columns-1 xl:columns-2` + `break-inside-avoid`) instead of one infinite column — roughly halves the desktop scroll. One column on smaller screens (unchanged).
- **Backend**: `/api/status` now reports the configured `proxy_port` from the DB instead of a hard-coded `"3128"`.

## Verification (live)

Set `proxy_port = 3129` via the API → `/api/status` returned `proxy_port: 3129` (was always `3128`). Status `running`, version `3.4.6`, requests_count populated. `go build`/`go vet` green; `tsc -b && vite build` green; UI served 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)