### PR TITLE
release: v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-06-04
+
+### Added
+
+- **Audit Log page (#82).** A paginated, filterable view of administrative
+  actions — logins, blacklist and settings changes, maintenance — with
+  per-action badges and CSV export, backed by the existing `/api/audit-log`.
+  Backend audit coverage was widened to also record blacklist additions and
+  settings changes.
+- **Clients page (#83).** A sortable table of source IPs (requests, blocked,
+  block rate, last seen) with a per-client drill-down drawer (top destinations
+  with blocked counts, recent requests), backed by an enriched
+  `/api/clients/statistics` and a new `GET /api/clients/{ip}/details` endpoint.
+- **Service-status panel in Settings (#84).** Live proxy up/down, listen
+  address, version, clients seen, 24h request/block counts and cache hit rate
+  at the top of the page. The setting cards now flow into two columns on wide
+  screens to cut the scrolling, and `/api/status` reports the configured
+  `proxy_port` from the database instead of a hard-coded value.
+- **End-to-end CI smoke job (#85).** A new `E2E (compose up + smoke)` job runs
+  the whole stack with `docker compose up` and exercises the core path —
+  service health, proxy egress, the blacklist watchdog, the Squid→backend log
+  pipeline, and the audit log — so fresh-deploy breakage can no longer ship
+  green. It is enforced as a required status check via branch protection.
+
+### Changed
+
+- **No movement on hovered data.** Table rows now highlight with colour only;
+  the previous `transform: translateX(2px)` on `.row-hover`, which shifted
+  every row under the cursor, was removed across the Logs, Blacklists, Clients
+  and Audit tables.
+
 ## [3.4.6] - 2026-06-04
 
 ### Fixed

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.4.6"
+const AppVersion = "3.5.0"


### PR DESCRIPTION
Tags the work that landed on \`main\` since v3.4.6 as a minor release.

## Included

- **Audit Log page (#82)** — paginated, filterable admin-action view with badges and CSV export; backend audit coverage widened to blacklist/settings changes.
- **Clients page (#83)** — sortable source-IP table (requests, blocked, block rate, last seen) + per-client drill-down drawer; new \`GET /api/clients/{ip}/details\`.
- **Service-status panel in Settings (#84)** — live proxy state, listen address, version, 24h request/block counts, cache hit rate; two-column card layout; \`/api/status\` reports \`proxy_port\` from the DB.
- **End-to-end CI smoke job (#85)** — \`E2E (compose up + smoke)\` runs the whole stack and exercises the core path; now a required status check via branch protection.
- **No movement on hovered data** — colour-only row highlight across Logs, Blacklists, Clients, Audit.

## Notes

This PR is the first to run under the new branch protection: it must pass all nine required checks — including the ~8-minute \`E2E (compose up + smoke)\` job — before it can merge. No admin bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)