### PR TITLE
security wave 1: harden WAF/SSRF/docker/secrets, supply-chain + perf/UX (CA key purged from history)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,18 @@
 # ==============================================================================
 # AUTHENTICATION (required)
 # ==============================================================================
-# ⚠️  CHANGE THESE — containers will crash if empty!
+# ⚠️  You MUST set a strong admin password below before `docker compose up`.
+#     The backend refuses to start (by design) if it is empty or a common
+#     default ("changeme", "password", "admin", …) or shorter than 8 chars.
+#     Easiest path: run `bash deploy/install.sh`, which generates and PRINTS
+#     these credentials for you.
 BASIC_AUTH_USERNAME=admin
-BASIC_AUTH_PASSWORD=changeme
+BASIC_AUTH_PASSWORD=
 
-# JWT secret — auto-generates if empty (sessions lost on restart)
+# JWT secret — leave empty to auto-generate a strong one (persisted under
+# /data so sessions survive restart). If you DO set it, it must be a unique,
+# random, 32+ char value (`openssl rand -hex 32`); known/example values are
+# rejected at startup.
 SECRET_KEY=
 
 # ==============================================================================

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,23 @@ updates:
       docker-dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-dependencies:
+        patterns:
+          - "*"
+
+  # Keep the SHA-pinned GitHub Actions (ci.yml, multi-arch.yml, docs.yml)
+  # patched — pinning to a digest means we don't get upstream fixes otherwise.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Install Trivy
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/v0.58.1/contrib/install.sh \
-            | sh -s -- -b /usr/local/bin v0.58.1
+            | sudo sh -s -- -b /usr/local/bin v0.58.1
       - name: Scan dependencies for fixable high/critical CVEs
         run: |
           trivy fs --scanners vuln \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,25 @@ jobs:
         working-directory: waf-go
         run: gosec -severity medium -confidence medium -exclude=G104,G114,G301,G302,G304 ./...
 
+      # govulncheck complements gosec (a SAST linter) with the Go vulnerability
+      # database: it flags known-CVE dependencies AND stdlib issues, but only when
+      # the vulnerable symbol is actually reachable. Reported (continue-on-error)
+      # rather than gated, because stdlib advisories track the Go toolchain patch
+      # level and would otherwise red-fail unrelated PRs on every disclosure until
+      # the toolchain is bumped (handled by the github-actions/gomod Dependabot).
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: Run govulncheck on backend-go
+        working-directory: backend-go
+        continue-on-error: true
+        run: govulncheck ./...
+
+      - name: Run govulncheck on waf-go
+        working-directory: waf-go
+        continue-on-error: true
+        run: govulncheck ./...
+
       - name: npm audit (UI)
         working-directory: ui
         run: |
@@ -118,6 +137,31 @@ jobs:
           # silently passed a critical-only gate. Moderate is intentionally not
           # gated (current brace-expansion devDep advisory has no clean fix).
           npm audit --audit-level=high
+
+  # ── 6b. Trivy filesystem CVE + misconfiguration scan ──────────────────
+  # Catches vulnerable OS/library packages and IaC misconfigurations that gosec
+  # (Go SAST) and npm audit (JS deps) do not. Installed as a pinned binary
+  # rather than an unpinned action, matching this repo's supply-chain posture.
+  # Gates only on FIXABLE high/critical findings (--ignore-unfixed) to stay
+  # actionable.
+  trivy-scan:
+    name: Trivy CVE scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/v0.58.1/contrib/install.sh \
+            | sh -s -- -b /usr/local/bin v0.58.1
+      - name: Scan dependencies for fixable high/critical CVEs
+        run: |
+          trivy fs --scanners vuln \
+            --severity HIGH,CRITICAL --ignore-unfixed \
+            --exit-code 1 --no-progress .
+      - name: Report IaC misconfigurations (non-gating)
+        run: |
+          trivy fs --scanners misconfig \
+            --severity HIGH,CRITICAL --exit-code 0 --no-progress .
 
   # ── 7. Docker build verification ──────────────────────────────────────
   docker-build:

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -72,3 +72,7 @@ jobs:
             ${{ env.IMAGE_PREFIX }}-${{ matrix.image }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Attach an SBOM and SLSA build provenance attestation to each image so
+          # consumers can audit contents and verify the build origin.
+          sbom: true
+          provenance: mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,11 @@ config/dnsmasq.d/
 config/squid_settings.env
 config/custom_squid_extra.conf
 
+# TLS material — NEVER commit. The SSL-bump CA is generated per-deployment at
+# first boot (proxy/startup.sh). Committing it shares one private key with every
+# user and enables MITM of all bumped TLS.
+config/*.pem
+config/ssl_db/
+
 # Claude Code working directory (worktrees, settings, transcripts)
 .claude/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -48,22 +48,31 @@ If you want to get up and running quickly with default settings:
 git clone https://github.com/fabriziosalmi/secure-proxy-manager.git
 cd secure-proxy-manager
 
-# 2. Run the initialization script
-chmod +x init.sh
-./init.sh
+# 2. Create your .env with strong credentials
+cp .env.example .env
+$EDITOR .env   # set BASIC_AUTH_PASSWORD (see notes below)
 
-# 3. Start the services
-docker-compose up -d
+# 3. Build and start the services
+docker compose up -d --build
 
 # 4. Check the logs
-docker-compose logs -f
+docker compose logs -f
 
 # 5. Access the web interface
-# Open your browser to: http://localhost:8011
+# Open your browser to: https://localhost:8443  (accept the self-signed cert)
 # Log in with the credentials you set in .env
 ```
 
-**Note**: `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` must be set in `.env` before starting. The services refuse to start if these are empty or set to `admin`.
+Or, for a one-command install on a fresh VPS (generates and prints credentials
+for you):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/fabriziosalmi/secure-proxy-manager/main/deploy/install.sh | sudo bash
+```
+
+**Note**: `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` must be set in `.env`
+before starting. The backend refuses to start if the password is empty, a common
+default (`changeme`, `admin`, `password`, …), or shorter than 8 characters.
 
 ## Step-by-Step Deployment
 
@@ -76,21 +85,20 @@ cd secure-proxy-manager
 
 ### Step 2: Prepare the Environment
 
-#### Option A: Using the Initialization Script (Recommended)
+#### Option A: Using the Installer (Recommended)
 
-The initialization script will create all necessary directories and files:
+`deploy/install.sh` provisions everything on a fresh host:
 
 ```bash
-chmod +x init.sh
-./init.sh
+curl -fsSL https://raw.githubusercontent.com/fabriziosalmi/secure-proxy-manager/main/deploy/install.sh | sudo bash
 ```
 
 This script will:
 - Check for Docker and Docker Compose installation
 - Create required directories (`config`, `data`, `logs`)
 - Create empty blacklist files if they don't exist
-- Create a `.env` file from `.env.example` if it doesn't exist
-- Set proper permissions
+- Generate a `.env` with strong, random credentials and print them
+- Build and start the stack
 
 #### Option B: Manual Setup
 
@@ -166,16 +174,17 @@ docker-compose logs -f
 ```
 
 Look for these success messages in the logs:
-- Backend: `"Gunicorn is running on http://0.0.0.0:5000"`
-- Web UI: `"Running on http://0.0.0.0:8011"`
+- Backend (Go): `"HTTP server listening"` on port `5000` (internal)
+- Web UI (nginx): serving on `8443` (HTTPS) / `8011` (HTTP redirect)
 - Proxy: `"Squid configuration syntax is valid"`
 
 ### Step 6: Access the Web Interface
 
 1. Open your web browser and navigate to:
    ```
-   http://localhost:8011
+   https://localhost:8443
    ```
+   (accept the self-signed certificate; plain `http://localhost:8011` redirects here)
 
 2. Enter your credentials:
    - Username: `admin` (or what you set in `.env`)
@@ -232,7 +241,7 @@ All configuration is done through the `.env` file. Here are the key variables:
 |----------|---------|-------------|
 | `BASIC_AUTH_USERNAME` | required | Username for web UI and API access |
 | `BASIC_AUTH_PASSWORD` | required | Password for web UI and API access |
-| `SECRET_KEY` | Auto-generated | Flask session secret (generate with `secrets.token_hex(32)`) |
+| `SECRET_KEY` | Auto-generated | JWT signing secret. Leave empty to auto-generate and persist under `/data`. If set, must be unique, random and 32+ chars (`openssl rand -hex 32`); known/example values are rejected at startup. |
 
 #### Backend API
 | Variable | Default | Description |
@@ -606,8 +615,9 @@ Set up health monitoring:
 
 ```bash
 # Check health endpoints
-curl -I http://localhost:8011/health
-curl -I http://localhost:5001/health
+curl -I http://localhost:8011/health          # web UI (nginx)
+curl -I http://127.0.0.1:5001/health          # backend API (bound to localhost)
+curl -skI https://localhost:8443/             # web UI over HTTPS
 
 # Set up monitoring with tools like:
 # - Prometheus + Grafana

--- a/README.md
+++ b/README.md
@@ -1,1038 +1,231 @@
 # Secure Proxy Manager
 
-[![CI](https://github.com/fabriziosalmi/secure-proxy-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/fabriziosalmi/secure-proxy-manager/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![GitHub release](https://img.shields.io/github/v/release/fabriziosalmi/secure-proxy-manager)](https://github.com/fabriziosalmi/secure-proxy-manager/releases)
-[![Backend Coverage](https://img.shields.io/badge/backend--go--coverage-67%25-yellow.svg)](backend-go/)
-[![WAF Coverage](https://img.shields.io/badge/waf--go--coverage-70%25-brightgreen.svg)](waf-go/)
-[![Docker](https://img.shields.io/badge/deploy-Docker-2496ED?logo=docker)](docker-compose.yml)
+A self-hosted forward proxy with a web UI for filtering, inspecting, and logging
+outbound HTTP/HTTPS traffic on a network. It combines a Squid proxy, a custom
+WAF, a DNS sinkhole, and a management API into a single Docker Compose stack.
 
-**Monitor and secure all outbound traffic from your network.** Block malicious sites, detect data leaks, catch malware callbacks — with a dashboard you'll actually enjoy using.
+Use it to give a home, lab, or small-office network one controllable egress
+point: block domains and IPs, inspect requests against WAF rules, sinkhole
+malware/ad domains at the DNS layer, and see what every client is reaching.
 
-Think of it as "Pi-hole + WAF + egress firewall" in one Docker stack. No agents to install on clients — just point your devices to the proxy.
+![Dashboard](docs/screenshots/dashboard.png)
 
-Built for homelab, self-hosted, and SMB. Runs on **Raspberry Pi** (ARM64) and any x86 server.
+## What it is
 
-## Table of Contents
+The stack is five containers (plus an optional sixth):
 
-- [Screenshots](#screenshots)
-- [Quick Start](#quick-start)
-- [Benchmark Results](#benchmark-results)
-- [Key Features](#key-features)
-- [Architecture](#architecture)
-- [Installation](#installation)
-- [Configuration](#configuration)
-- [FAQ](#faq)
+| Service | Tech | Role |
+|---------|------|------|
+| `web` | React 19 + Vite, served by nginx | The management UI and HTTPS entry point. Terminates TLS, proxies the API and WebSocket. |
+| `backend` | Go (chi, modernc/sqlite, JWT) | REST API, log ingestion, settings, auth, background workers. ~20 MB RAM. |
+| `waf` | Go ICAP service | Inspects proxied requests/responses Squid hands off over ICAP. |
+| `proxy` | Squid (Ubuntu 22.04, `squid-openssl`) | The actual forward proxy on port 3128, with ICAP wired to the WAF. |
+| `dns` | dnsmasq | DNS resolver that sinkholes blacklisted domains at the network layer. |
+| `tailscale` | Tailscale (optional) | Sidecar for remote access over a private network. Enabled with a compose profile. |
 
-## Screenshots
+The backend talks to Squid and dnsmasq through the Docker Engine API to apply
+blacklist and config changes without restarting the host.
 
-<div align="center">
-  <img src="docs/screenshots/dashboard.png" alt="Dashboard" width="800"/>
-  <p><em>Dashboard — real-time traffic, threats, WAF intelligence, cache stats</em></p>
-</div>
+## Quick start
 
-<details>
-<summary><strong>More screenshots</strong></summary>
+Requirements: Docker 20.10+ with Compose v2, ~512 MB RAM, ~2 GB disk. Runs on
+x86_64 and ARM64.
 
-<div align="center">
-  <img src="docs/screenshots/threat-intel.png" alt="Threat Intelligence" width="800"/>
-  <p><em>Threat Intel — Shadow IT, file types, service types, domain cloud, regex playground</em></p>
-  <br/>
-  <img src="docs/screenshots/blacklists.png" alt="Blacklists" width="800"/>
-  <p><em>Blacklists — 34K+ IPs, 87K+ domains, paginated with search</em></p>
-  <br/>
-  <img src="docs/screenshots/access-logs.png" alt="Access Logs" width="800"/>
-  <p><em>Access Logs — real-time WebSocket stream with filtering</em></p>
-  <br/>
-  <img src="docs/screenshots/settings.png" alt="Settings" width="800"/>
-  <p><em>Settings — 6 presets, client setup, notifications, WAF heuristics</em></p>
-</div>
+**One command (fresh VPS or server):**
 
-</details>
-
-## Quick Start
-
-```bash
-# One-command install (any Linux VPS or server)
-curl -fsSL https://raw.githubusercontent.com/fabriziosalmi/secure-proxy-manager/main/deploy/install.sh | sudo bash
-
-# Or manually:
-git clone https://github.com/fabriziosalmi/secure-proxy-manager.git
-cd secure-proxy-manager
-cp .env.example .env   # edit credentials
-docker compose up -d --build
-
-# Open: https://localhost:8443 (accept self-signed cert)
-# Run E2E tests: ./tests/e2e.sh localhost admin password
-```
-
-## Benchmark Results
-
-| Metric | Value |
-|--------|-------|
-| E2E Tests | **104 checks, 99 passed, 0 failed** |
-| WAF Rules | **175 regex + 7 heuristic + 3 ML-lite** |
-| Security Packs | **23 toggleable categories** |
-| Attack Detection | **17/17 (100%)** |
-| False Positives | **0/7 (0%)** |
-| Evasion Resistance | **5/5 (double-encode, case-mix, null byte, unicode, long payload)** |
-| P50 Latency | **107ms** (with full ICAP inspection) |
-| Backend Memory | **~20MB** (Go binary) |
-| Backend Binary | **16MB** (single file, zero dependencies) |
-| Platforms | **linux/amd64 + linux/arm64** (Raspberry Pi) |
-
-## Key Features
-
-### Core
-- **Go Backend**: Single 16MB binary, ~20MB RAM. Zero Python dependencies.
-- **WAF Engine (Go ICAP)**: 175 regex + 7 heuristics + 3 ML-lite across 23 categories. Anomaly scoring, Shannon entropy, dual-scan (raw + normalized).
-- **Security Packs**: 23 toggleable WAF rule categories — enable/disable SQLi, XSS, C2, DLP packs from the API.
-- **DNS Blackhole**: dnsmasq blocks 87K+ domains at L3 (zero HTTP overhead).
-- **HTTPS by Default**: Self-signed TLS auto-generated. Optional Let's Encrypt with certbot.
-- **Multi-Arch**: Runs on x86_64 and ARM64 (Raspberry Pi 4/5).
-
-### Intelligence
-- **ML-Lite Detection**: DGA domains (bigram analysis), typosquatting (Levenshtein + homoglyph), safe URL cache.
-- **Threat Intel Dashboard**: Shadow IT (35+ SaaS), file types, service types, domain cloud, live feed.
-- **Regex Playground**: Test new WAF rules against real traffic before deploying.
-- **Squid CVE Alert**: Detects known vulnerabilities in your Squid version.
-- **Update Notifier**: Checks GitHub releases, shows badge when update available.
-
-### Onboarding & UX
-- **Glass Morphism UI**: Aerospace-grade dark theme with `backdrop-blur` glass surfaces, animated number counters, staggered page transitions, progress bar glow, and frosted ⌘K search modal.
-- **Setup Wizard**: First-login 3-step wizard (environment → devices → strictness).
-- **6 Presets**: Basic, Family, Standard, Paranoid, DevOps, Kiosk — one-click configuration.
-- **Client Setup Export**: Per-OS instructions (Win/Mac/Linux/iOS/Android) + PAC file download.
-- **WPAD Auto-Discovery**: Browsers auto-detect proxy via `wpad.dat` — zero client config.
-- **Extra SSL Ports**: Allow HTTPS CONNECT on non-standard ports (e.g. Proxmox 8006, Grafana 3000) from Settings.
-- **Pi-hole/AdGuard Detect**: Scans LAN for existing DNS providers, offers to cooperate.
-- **DoH Blocker**: Blocks 14 DNS-over-HTTPS providers to prevent blackhole bypass.
-- **GDPR Mode**: Anonymize client IPs in logs (last octet → x) for EU compliance.
-
-### Security Hardening (v3.1)
-- **Encryption at Rest**: Sensitive settings (webhook URLs, API tokens) encrypted with AES-256-GCM in the database.
-- **Persistent JWT Blacklist**: Revoked tokens survive container restarts via SQLite persistence.
-- **Global Rate Limiting**: Token bucket per-IP (20 req/s, burst 60) on all endpoints.
-- **Circuit Breaker**: WAF calls protected against cascading failures (auto-recovery).
-- **Notification Retry**: Failed deliveries retry 3x with exponential backoff.
-- **Tightened CSP**: Removed `unsafe-eval`, restricted `connect-src` to self + WebSocket.
-- **pprof Profiling**: Auth-protected `/debug/pprof/*` endpoints for production debugging.
-- **CI Security Scanning**: gosec + npm audit + backend test coverage threshold in GitHub Actions.
-
-### Operations
-- **One-Click Deploy**: `curl | bash` installer + cloud-init YAML for Hetzner/DO/Linode.
-- **API Documentation**: `GET /api/docs` — 60+ endpoints with descriptions.
-- **E2E Test Suite**: 104 checks across 3 parts — `./tests/e2e.sh host user pass`.
-- **Notifications**: Telegram, Discord, Gotify, ntfy.sh, MS Teams, custom webhook — with retry and backoff.
-- **Protocol Hardening**: Method whitelist (`Safe_methods`), header stripping, HSTS, max header size, outbound TLS hardened to 1.2+ with ECDHE-only cipher list.
-- **Prometheus metrics**: WAF exposes `/metrics` (port 8080) — `waf_requests_total`, `waf_blocked_total`, `waf_high_entropy_total`, `waf_block_threshold`, cache hits/size and more. Aggregate counters only — no rule names or destinations are leaked.
-- **Audit Trail**: Who changed what, when — `/api/audit-log`.
-- **Blocklists**: 16 popular sources, geo-blocking, paginated UI with search.
-- **Custom Block Pages**: Branded dark-theme error pages.
-
-## Architecture
-
-The project employs a microservices architecture:
-
-1. **Frontend (React 19/Vite/Nginx)**: Glass morphism design system with animated counters, staggered transitions, and frosted overlays. SPA with @tanstack/react-query, Recharts dashboards, paginated blacklists, Threat Intel page with Shadow IT/file types/domain cloud, global search (⌘K), mobile responsive.
-2. **Backend (Go)**: Single 16MB binary (chi router, zerolog, modernc/sqlite). 70+ endpoints, WebSocket log streaming, JWT auth + persistent blacklist, AES-256-GCM encrypted settings, global rate limiting, circuit breaker for WAF calls, pprof profiling, audit logging, SSRF-safe HTTP client with DNS pinning.
-3. **Proxy Engine (Squid 5.9)**: Caching/filtering with ICAP integration, custom branded block pages, IP ACL blocking, protocol hardening (method whitelist, header stripping, HSTS).
-4. **WAF Engine (Go ICAP)**: 175 regex rules across 23 categories + 7 behavioral heuristics + 3 ML-lite checks (DGA, typosquatting, safe URL cache). Anomaly scoring, Shannon entropy, dual-scan (raw + normalized).
-5. **DNS Blackhole (dnsmasq)**: Internal DNS resolver that sinkhole-blocks 87K+ blacklisted domains at L3. Supports 600K+ entry blocklists with tuned memory and healthcheck timing.
-6. **Tailscale Sidecar** (optional): Secure remote access overlay network.
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/fabriziosalmi/secure-proxy-manager/main/docs/architecture.svg" alt="Secure Proxy Manager Architecture" width="800"/>
-</div>
-
-### Project Structure
-
-```
-secure-proxy-manager/
-├── backend-go/               # Go backend
-│   ├── cmd/server/main.go    # Entry point, router, graceful shutdown
-│   └── internal/
-│       ├── auth/             # JWT + Basic Auth, rate limiting, persistent token blacklist
-│       ├── config/           # Environment-based configuration + key management
-│       ├── crypto/           # AES-256-GCM encryption for sensitive settings
-│       ├── database/         # SQLite WAL, schema, migrations, atomic exports
-│       ├── docker/           # Docker API client (Squid/dnsmasq signaling)
-│       ├── handlers/         # HTTP handlers (auth, blacklists, analytics, etc.)
-│       ├── middleware/       # CORS, rate limiting, circuit breaker, security headers
-│       ├── websocket/        # WebSocket hub with client lifecycle
-│       └── workers/          # Background: log tailing, retention, auto-refresh (context-aware)
-├── ui/                       # React 19 frontend
-│   └── src/
-│       ├── pages/            # Dashboard, Blacklists, ThreatIntel, Logs, Settings, Login
-│       ├── hooks/            # useAnimatedNumber (rAF counter interpolation)
-│       ├── lib/api.ts        # Axios + JWT expiry + react-query
-│       └── public/logo.svg   # Gear+eye SVG logo
-├── proxy/                    # Squid proxy service
-│   ├── startup.sh            # Config generator with IP blocking + dnsmasq wiring
-│   └── error-pages/          # Custom branded dark-theme block pages
-├── waf-go/                   # Go ICAP WAF engine (10 modules)
-│   ├── main.go               # ICAP handlers, safe URL cache integration
-│   ├── rules.go              # 175 regex rules across 23 categories
-│   ├── heuristics.go         # 7 behavioral anomaly detection rules
-│   ├── bloom.go              # Safe URL cache (skip regex for known-clean URLs)
-│   ├── dga.go                # DGA domain detection (bigram + entropy analysis)
-│   ├── typosquat.go          # Typosquatting detection (Levenshtein + homoglyphs)
-│   ├── entropy.go            # Shannon entropy, JSONL traffic profiler
-│   ├── stats.go              # Real-time metrics collector
-│   ├── normalize.go          # Anti-evasion input normalization (dual-scan)
-│   ├── fuzz_test.go          # Evasion + false positive + stability fuzzing
-│   └── main_test.go          # 80+ test cases + benchmarks
-├── dns/                      # dnsmasq DNS blackhole sidecar
-│   ├── dnsmasq.conf          # Upstream DNS + blocklist include
-│   └── Dockerfile
-├── scripts/
-│   └── benchmark.sh          # 360-degree reproducible benchmark suite
-├── config/                   # Shared volumes (blacklists, SSL, dnsmasq)
-├── data/                     # SQLite DB + WAF traffic JSONL
-├── BENCHMARKS.md             # Live performance & security results
-├── CHANGELOG.md
-├── docker-compose.yml        # 6-service stack (Go backend)
-├── deploy/install.sh         # One-command installer for any VPS
-└── tests/e2e.sh              # 104-check E2E test suite
-```
-
-## Installation
-
-### Requirements
-- Docker 20.10+ with Compose v2
-- 1 CPU, 512MB RAM, 2GB disk
-
-### Ports used
-| Port | Service | Required |
-|------|---------|----------|
-| 443 / 8443 | HTTPS (Web UI) | ✅ |
-| 80 / 8011 | HTTP (redirect + ACME) | ✅ |
-| 3128 | Proxy (configure clients here) | ✅ |
-| 5001 | Backend API (WebSocket) | Optional |
-
-### Option A: One-command install (recommended)
 ```bash
 curl -fsSL https://raw.githubusercontent.com/fabriziosalmi/secure-proxy-manager/main/deploy/install.sh | sudo bash
 ```
-This installs Docker if needed, generates random credentials, builds, and starts everything.
 
-### Option B: Manual setup
+The installer checks for Docker, generates random admin credentials, builds the
+images, and starts the stack. It prints the credentials at the end.
+
+**Manual:**
+
 ```bash
 git clone https://github.com/fabriziosalmi/secure-proxy-manager.git
 cd secure-proxy-manager
 cp .env.example .env
-nano .env                    # set BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD
+# Set a strong BASIC_AUTH_PASSWORD in .env (the backend refuses to start with an
+# empty, common, or <8-char password). Leave SECRET_KEY empty to auto-generate.
 docker compose up -d --build
 ```
 
-### First login
-1. Open **https://localhost:8443** (accept the self-signed certificate)
-2. Log in with the credentials from `.env`
-3. The **Setup Wizard** guides you through configuration (choose preset, devices, strictness)
-4. Configure client devices: set proxy to `your-server-ip:3128`
+Then open <https://localhost:8443> and accept the self-signed certificate. Log in
+with the credentials from your `.env` (or the ones the installer printed). On
+first login a short wizard helps you pick a starting configuration.
 
-### Updating
+To send traffic through the proxy, point a client at `http://<host>:3128`
+(Settings > Client Setup generates per-OS instructions and a PAC file).
+
+## Ports
+
+| Port | Service | Notes |
+|------|---------|-------|
+| 443, 8443 | Web UI (HTTPS) | Main interface. 8443 is the same UI on an alternate port. |
+| 80, 8011 | HTTP | Redirects to HTTPS; also serves ACME challenges for Let's Encrypt. |
+| 3128 | Proxy | Point clients here. Only RFC1918/localhost sources are allowed by default. |
+| 5001 | Backend API | Bound to `127.0.0.1` on the host; the UI proxies it internally. |
+
+## Configuration
+
+All configuration is environment-driven via `.env` (see `.env.example` for the
+full list with comments). The essentials:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `BASIC_AUTH_USERNAME` / `BASIC_AUTH_PASSWORD` | required | Admin login. The backend refuses to start if the password is empty, a common default, or shorter than 8 characters. |
+| `SECRET_KEY` | auto-generated | JWT signing secret. Leave empty to generate and persist one. If set, it must be unique, random, and 32+ chars; known/example values are rejected at startup. |
+| `LETSENCRYPT_DOMAIN` / `LETSENCRYPT_EMAIL` | empty | Set both to obtain a real certificate via certbot instead of the self-signed one. |
+| `CORS_ALLOWED_ORIGINS` | `https://localhost:8443` | Allowed UI origin(s). |
+| `DNS_UPSTREAM_1..3` | malware-blocking resolvers | Upstream DNS for dnsmasq. Override to use your own (e.g. Pi-hole). |
+| `PROXY_IP` | empty | Your LAN IP, to enable WPAD auto-discovery (`wpad.dat`) for browsers. |
+| `WAF_BLOCK_THRESHOLD` | `10` | Anomaly score at which a request is blocked (lower is stricter). |
+| `WAF_FAIL_OPEN` | `0` | If the WAF handler errors, block (`0`, fail-closed) or allow (`1`) the request. |
+
+Most runtime behaviour (WAF categories, blocklists, filtering toggles,
+notifications) is managed from the UI and stored in the database, not in `.env`.
+
+## Features
+
+**Filtering**
+- Domain and IP blacklists and whitelists, managed in the UI or via the API,
+  importable from URLs or pasted content (with CIDR support for IPs).
+- DNS sinkholing of blacklisted domains via dnsmasq, so blocked lookups never
+  reach the proxy at all.
+- Direct-IP-access blocking and a method whitelist in Squid.
+
+**WAF**
+- 175 regex rules across 23 toggleable categories (SQLi, XSS, traversal, C2,
+  data-loss, etc.), each enableable/disableable at runtime.
+- 7 behavioural heuristics (entropy, beaconing, PII, sharding, morphing,
+  ghosting, sequence) plus DGA detection (bigram + entropy), typosquatting
+  detection (edit distance + homoglyphs), and a safe-URL fast-path cache.
+- Anti-evasion input normalization and anomaly scoring; fails closed on internal
+  errors by default.
+
+**HTTPS inspection (optional)**
+- HTTPS is tunnelled via `CONNECT` by default - the WAF sees connection metadata
+  (host, port), not request contents.
+- Enabling SSL-bump in Settings makes Squid intercept TLS with a locally
+  generated CA so the WAF can inspect decrypted requests. This requires
+  installing the generated CA (Settings > download CA) on every client that
+  should trust it. The CA is generated per deployment at first boot.
+
+**Operations**
+- Live dashboard, per-client drill-down, searchable access logs, and an audit
+  log of configuration changes.
+- Prometheus metrics from the WAF at `:8080/metrics` (aggregate counters only).
+- Notifications to a custom webhook, Gotify, Telegram, or Microsoft Teams, with
+  retry and backoff.
+- WebSocket log streaming, JWT auth with a persistent revocation list, per-IP
+  rate limiting, and AES-256-GCM encryption of sensitive settings at rest.
+- Optional Let's Encrypt, WPAD/PAC client auto-config, and a Tailscale sidecar.
+
+## Using it
+
+**Point a client at the proxy.** Set the HTTP/HTTPS proxy to `http://<host>:3128`
+on the device, or use the PAC file / WPAD auto-discovery from Settings > Client
+Setup. Only RFC1918 and localhost sources are permitted by default.
+
+**Block a domain.** Blacklists > Domains > add `example.com`. The change is
+exported to Squid and dnsmasq within a couple of seconds. Whitelists take
+precedence.
+
+**Inspect HTTPS.** Settings > enable SSL inspection, download the generated CA,
+and install it as trusted on your clients. Without this, HTTPS requests are only
+filtered by host/IP and DNS, not by WAF body rules.
+
+**Import a blocklist.** Blacklists > Import supports popular public lists by URL
+or pasted content. Imports are size-bounded and fetched with an SSRF-safe client
+that refuses private/internal targets.
+
+## Updating
+
 ```bash
 cd secure-proxy-manager
 git pull
 docker compose up -d --build
 ```
 
-### Need Help?
+Your `.env`, database, and blacklists live in bind-mounted volumes and are
+preserved across updates. The backend checks GitHub for newer releases and shows
+a badge in the UI when one is available.
 
-- **New to Docker?** See our comprehensive [DEPLOYMENT.md](DEPLOYMENT.md) guide
-- **Encountering issues?** Check the [Troubleshooting](#troubleshooting) section below
-- **Want detailed setup instructions?** Read the full [Deployment Guide](DEPLOYMENT.md)
+## Backup and restore
 
-## Configuration Options
-
-### Environment Variables
-
-All values are read from `.env` (copy from `.env.example`). Tables list every variable wired to a service in `docker-compose.yml`; defaults match the compose file.
-
-#### Authentication
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `BASIC_AUTH_USERNAME` | HTTP Basic auth username | required |
-| `BASIC_AUTH_PASSWORD` | HTTP Basic auth password (services refuse to start with the placeholder values) | required |
-| `SECRET_KEY` | HMAC key used to sign JWT access and refresh tokens | auto-generated when empty |
-
-#### Backend
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `PROXY_HOST` | Squid container hostname used for reload requests | `proxy` |
-| `PROXY_PORT` | Squid proxy port | `3128` |
-| `PROXY_CONTAINER_NAME` | Docker container name used for reconfigure signals | `secure-proxy-manager-proxy` |
-| `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed CORS origins | `https://localhost:8443` |
-
-#### Web UI (`web` service)
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `BACKEND_URL` | Backend API URL on the internal Docker network | `http://backend:5000` |
-| `REQUEST_TIMEOUT` | UI request timeout in seconds | `120` |
-| `LETSENCRYPT_DOMAIN` | When set with `LETSENCRYPT_EMAIL`, provisions a real certificate | empty |
-| `LETSENCRYPT_EMAIL` | ACME account email | empty |
-
-#### Proxy / DNS
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `PROXY_BIND_IP` | Host interface that the Squid port is bound to | `0.0.0.0` |
-| `PROXY_IP` | LAN IP of the host. When set, dnsmasq publishes a WPAD record for browser auto-discovery | empty |
-| `GUI_IP_WHITELIST` | Comma-separated client IPs allowed to reach the management plane | empty |
-| `DNS_UPSTREAM_1` | Primary upstream resolver | `1.1.1.3` |
-| `DNS_UPSTREAM_2` | Secondary upstream resolver | `9.9.9.9` |
-| `DNS_UPSTREAM_3` | Tertiary upstream resolver | `8.8.8.8` |
-
-#### WAF
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `WAF_BLOCK_THRESHOLD` | Anomaly score at or above which a request is blocked | `10` |
-| `WAF_DISABLED_CATEGORIES` | Comma-separated rule categories to disable globally | empty |
-| `WAF_H_ENTROPY` / `WAF_H_ENTROPY_MAX` | Toggle the Shannon entropy heuristic and its threshold | `1` / `7.5` |
-| `WAF_H_BEACONING` | Toggle C2 beaconing detection | `1` |
-| `WAF_H_PII` | Toggle PII leak counter | `1` |
-| `WAF_H_SHARDING` | Toggle destination sharding heuristic | `1` |
-| `WAF_H_GHOSTING` | Toggle protocol ghosting heuristic | `1` |
-| `WAF_H_MORPHING` | Toggle header morphing heuristic | `0` |
-| `WAF_H_SEQUENCE` | Toggle sequence validation heuristic | `0` |
-
-#### Tailscale (optional, `--profile tailscale`)
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `TS_AUTHKEY` | Tailscale authentication key | empty (sidecar refuses to start without one) |
-| `TAILSCALE_HOSTNAME` | Hostname registered on the tailnet | `secure-proxy` |
-
-### Security Configuration
-
-**Security Considerations:**
-
-1. **Set Credentials**: `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` must be set before starting. There are no built-in defaults — the services refuse to start if these are empty or set to `admin`.
-   ```yaml
-   # In .env:
-   BASIC_AUTH_USERNAME=your_username
-   BASIC_AUTH_PASSWORD=your_password
-   ```
-
-2. **HTTPS for Web UI**: For production deployments, use a reverse proxy (e.g., nginx, Traefik) with SSL/TLS to secure the web interface.
-
-3. **Network Isolation**: Consider running the proxy in an isolated network segment with strict firewall rules.
-
-4. **Regular Updates**: Keep the system and Docker images updated with security patches.
-
-5. **Audit Logs**: Regularly review access logs and security events for suspicious activity.
-
-### Security Features
-
-| Feature | Description | Configuration |
-|---------|-------------|--------------|
-| IP Blacklisting | Block specific IP addresses or ranges | Web UI > Blacklists > IP |
-| Domain Blacklisting | Block specific domains (wildcard support) | Web UI > Blacklists > Domains |
-| Content Filtering | Block specific file types | Web UI > Settings > Filtering |
-| HTTPS Filtering | Inspect and filter HTTPS traffic | Web UI > Settings > Security |
-| Global Rate Limiting | Token bucket per-IP (20 req/s, burst 60) | Auto-configured |
-| Encryption at Rest | Sensitive tokens/URLs encrypted with AES-256-GCM | Auto-configured |
-| JWT Blacklist | Persistent across restarts via SQLite | Auto-configured |
-| Circuit Breaker | WAF calls protected against cascading failures | Auto-configured |
-| Security Scanning | gosec + npm audit in CI pipeline | `.github/workflows/ci.yml` |
-
-### Performance Tuning
-
-| Setting | Description | Default | Recommended |
-|---------|-------------|---------|------------|
-| Cache Size | Disk space allocated for caching | 2 GB | 5–10 GB for production |
-| Max Object Size | Maximum size of cached objects | 100 MB | up to 100 MB for media-heavy usage |
-| Connection Timeout | Timeout for stalled connections | 30 s | 15–60 s based on network |
-| DNS Timeout | Timeout for DNS lookups | 5 s | 3–10 s based on DNS infrastructure |
-
-## Advanced Configuration
-
-### Custom SSL Certificate
-
-For HTTPS filtering with your own certificate:
-
-1. Place your certificate and key in the `config/` directory:
-   - `ssl_cert.pem`: Your SSL certificate
-   - `ssl_key.pem`: Your private key
-
-2. Enable HTTPS filtering in the web interface:
-   - Settings > Security > Enable HTTPS Filtering
-
-3. **Important:** Install the certificate on all client devices to avoid browser security warnings
-   - **Windows**: Import to Trusted Root Certification Authorities
-   - **macOS**: Add to Keychain and trust for SSL
-   - **Linux**: Copy to `/usr/local/share/ca-certificates/` and run `update-ca-certificates`
-   - **Mobile**: Email the certificate and install via device settings
-
-**Note:** HTTPS filtering performs man-in-the-middle inspection. Only use this feature in environments where you have authorization to inspect traffic (e.g., corporate networks, your own devices).
-
-### Transparent Proxy Setup
-
-To use Secure Proxy as a transparent proxy:
-
-1. Configure iptables on your router/gateway:
-   ```bash
-   iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80  -j REDIRECT --to-port 3128
-   iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 3128
-   ```
-
-2. Enable transparent proxy mode in the web interface:
-   - Settings > Advanced > Transparent Mode
-
-### Extending Blacklists
-
-Integrate with external threat intelligence sources. The system supports importing plain text files (one entry per line) and JSON formats.
-
-#### 1-Click Popular Lists Import
-
-The "Popular Lists" button in the Web UI imports well-known public blocklists directly:
-
-**For Domains:**
-- *Aggregated Blacklist* (`fabriziosalmi/blacklists`) — ~2.9 M entries, 61 aggregated sources, daily refresh
-- *StevenBlack Unified* — adware and malware hosts from multiple curated sources
-- *URLhaus Malware* — abuse.ch active malware distribution domains
-- *Phishing Army* — domains actively involved in phishing
-- *OISD Big*, *HaGeZi Multi Pro*, *NoTracking*, *DanPollock Hosts*
-
-**For IPs:**
-- *Firehol Level 1* — general-purpose blocklist of active threats
-- *Spamhaus DROP* and *EDROP* — direct malware/botnet infrastructure
-- *Emerging Threats* — compromised hosts and botnet C2
-- *CINS Army*, *Stamparm Ipsum (L3+)*, *Blocklist.de*, *Talos Intelligence*
-
-#### Manual Import from URL
+The database (`data/`), config (`config/`), and `.env` hold all state.
 
 ```bash
-AUTH="Authorization: Basic $(echo -n YOUR_USER:YOUR_PASS | base64)"
-
-# Import domains from URL (plain text, one domain per line)
-curl -X POST https://localhost:8443/api/blacklists/import \
-  -H "Content-Type: application/json" \
-  -H "$AUTH" \
-  -d '{"type": "domain", "url": "https://example.com/domain-blacklist.txt"}'
-
-# Import domains from inline content
-curl -X POST https://localhost:8443/api/blacklists/import \
-  -H "Content-Type: application/json" \
-  -H "$AUTH" \
-  -d '{"type": "domain", "content": "example.com\n*.badsite.org\nmalicious.net"}'
-```
-
-#### Import IP Blacklists
-
-```bash
-AUTH="Authorization: Basic $(echo -n YOUR_USER:YOUR_PASS | base64)"
-
-# Import IPs from URL
-curl -X POST https://localhost:8443/api/blacklists/import \
-  -H "Content-Type: application/json" \
-  -H "$AUTH" \
-  -d '{"type": "ip", "url": "https://example.com/ip-blacklist.txt"}'
-
-# Import IPs from inline content with CIDR notation support
-curl -X POST https://localhost:8443/api/blacklists/import \
-  -H "Content-Type: application/json" \
-  -H "$AUTH" \
-  -d '{"type": "ip", "content": "192.168.1.100\n10.0.0.5\n172.16.0.0/24"}'
-```
-
-#### Supported File Formats
-
-- **Plain Text**: One entry per line (recommended for most blacklists)
-- **JSON Array**: `["example.com", "malicious.net"]`  
-- **JSON Objects**: `[{"domain": "example.com", "description": "Blocked site"}]`
-- **Comments**: Lines starting with `#` are ignored
-
-**Note:** For scheduled automatic blacklist updates, consider setting up a cron job or scheduled task that calls the import endpoints with your preferred blacklist sources.
-
-## Monitoring and Analytics
-
-### Dashboard Metrics
-
-- **Proxy Status**: Operational status
-- **Traffic Statistics**: Request volume over time
-- **Resource Usage**: Memory and CPU consumption
-- **Cache Performance**: Hit ratio and response time
-- **Security Score**: Security assessment
-
-### Logging and Analysis
-
-All proxy traffic is logged and can be analyzed in the web interface:
-
-- **Real-Time WebSockets**: View access logs streaming live from Squid to the UI via Go WebSocket server.
-- **Persistent Storage**: Logs are automatically written to the SQLite database (in WAL mode for concurrency) allowing historical search and pagination.
-- **Quick Stats**: Instant metric cards showing Total Requests, Success rates, Blocked traffic, and Errors directly above the logs table.
-- **Security Events**: Authentication attempts and blocked requests by the WAF.
-
-### Health Checks
-
-Health status endpoints are available for monitoring:
-
-```bash
-curl -kI https://localhost:8443/health
-# or, for a local cleartext check on the alt port:
-curl -I  http://localhost:8011/health
-```
-
-## Database Export and Backup
-
-### Database Export
-
-Export database contents including blacklists, settings, and logs (limited to 10,000 most recent entries):
-
-1. Via API:
-   ```bash
-   curl -X GET https://localhost:8443/api/database/export \
-     -H "Authorization: Basic $(echo -n YOUR_USER:YOUR_PASS | base64)" \
-     > secure-proxy-export.json
-   ```
-
-2. Via Direct Backend Access:
-   ```bash
-   curl -X GET http://localhost:5001/api/database/export \
-     -H "Authorization: Basic $(echo -n YOUR_USER:YOUR_PASS | base64)" \
-     > secure-proxy-export.json
-   ```
-
-### Manual Database Backup
-
-For complete database backup including all logs:
-
-```bash
-# Stop the services
 docker compose down
-
-# Backup the database file
-cp data/secure_proxy.db data/secure_proxy.db.backup
-
-# Backup configuration files
-tar -czf config-backup.tar.gz config/
-
-# Restart services
+cp data/proxy_manager.db proxy_manager.db.bak
+tar czf config.bak.tgz config/ .env
 docker compose up -d
 ```
 
-### Database Restore
+The UI also offers a config export/import under Settings, and the database can be
+exported via the API.
 
-To restore from a manual backup:
-
-```bash
-# Stop the services
-docker compose down
-
-# Restore the database file
-cp data/secure_proxy.db.backup data/secure_proxy.db
-
-# Restore configuration files
-tar -xzf config-backup.tar.gz
-
-# Restart services
-docker compose up -d
-```
-
-### Database Optimization
-
-Optimize database performance:
+## Health and testing
 
 ```bash
-curl -X POST https://localhost:8443/api/database/optimize \
-  -H "Authorization: Basic $(echo -n YOUR_USER:YOUR_PASS | base64)"
+# Service health
+curl -skI https://localhost:8443/            # UI
+curl -I http://127.0.0.1:5001/health         # backend API (localhost only)
+
+# Proxy a request
+curl -x http://localhost:3128 -I http://example.com
+
+# End-to-end suite (service health, proxy egress, blocking, log pipeline)
+bash tests/ci-e2e.sh
 ```
 
-### Database Statistics
-
-Get database size and statistics:
-
-```bash
-curl -X GET https://localhost:8443/api/database/stats \
-  -H "Authorization: Basic $(echo -n YOUR_USER:YOUR_PASS | base64)"
-```
-
-## Testing and Validation
-
-### Basic Connectivity Test
-
-```bash
-curl -x http://localhost:3128 http://example.com
-```
-
-### SSL Inspection Test
-
-```bash
-curl -x http://localhost:3128 https://example.com --insecure
-```
-
-### Blacklist Testing
-
-To test if blacklisting works:
-1. Add an IP or domain to the blacklist
-2. Attempt to access a resource from that IP or domain
-3. Verify the request is blocked (check logs)
-
-### Running the E2E Test Suite
-
-Run the comprehensive 104-check test suite against a live deployment:
-
-```bash
-# Full E2E: connectivity, WAF attacks, false positives, CRUD, settings, ML detection
-./tests/e2e.sh <HOST> <USER> <PASSWORD>
-
-# Example
-./tests/e2e.sh 192.168.100.253 admin mypassword
-```
-
-The test suite covers:
-- **Part A (Client)**: Proxy connectivity, 17 WAF attack vectors, 7 false positive checks, protocol hardening, latency
-- **Part B (Admin)**: Auth, 9 analytics endpoints, blacklist CRUD, settings, feature toggles, maintenance, database
-- **Part C (Advanced)**: Settings CRUD persistence, response body validation, WAF evasion (5 vectors), DGA/typosquatting detection, concurrent stress (10 parallel), error handling
-
-### Running WAF Unit Tests
-
-```bash
-cd waf-go && go test -v -count=1
-```
-
-## Frequently Asked Questions (FAQ)
-
-### General Questions
-
-**Q: What is Secure Proxy Manager?**  
-A: It's a containerized web proxy solution built on Squid with a modern management interface for filtering, monitoring, and controlling web traffic.
-
-**Q: Is this suitable for production use?**  
-A: Yes, but ensure you follow security best practices, change default credentials, and properly configure SSL certificates for HTTPS filtering.
-
-**Q: Can I use this in a corporate environment?**  
-A: Yes. It supports authentication, IP/domain blacklisting, and detailed logging. Ensure compliance with your organization's acceptable-use policies before deployment.
-
-### Installation & Setup
-
-**Q: Which ports need to be open?**  
-A: 443 / 8443 (Web UI HTTPS), 80 / 8011 (Web UI HTTP — redirects + ACME), and 3128 (proxy). The backend API on `127.0.0.1:5001` is bound to localhost only.
-
-**Q: Can I change the default credentials?**  
-A: Yes — set `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` in `.env` (copied from `.env.example`) before bringing the stack up. Containers refuse to start with the placeholder values.
-
-**Q: How do I update to the latest version?**  
-A:
-```bash
-git pull
-docker compose down
-docker compose build --no-cache
-docker compose up -d
-```
-
-### Features & Usage
-
-**Q: How do I import a large blacklist?**
-A: Use the import endpoint with a URL pointing to your blacklist file:
-```bash
-curl -X POST https://localhost:8443/api/blacklists/import \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Basic $(echo -n YOUR_USER:YOUR_PASS | base64)" \
-  -d '{"type": "domain", "url": "https://example.com/blacklist.txt"}'
-```
-
-**Q: Does it support IPv6?**  
-A: Yes, IPv6 addresses can be added to the IP blacklist, including CIDR notation.
-
-**Q: Can I filter HTTPS traffic?**  
-A: Yes, by enabling HTTPS filtering and installing the SSL certificate on client devices. Note: This performs man-in-the-middle inspection.
-
-**Q: How do I view blocked requests?**  
-A: Check the logs in the Web UI dashboard or query via API: `https://localhost:8443/api/logs/stats`
-
-### Performance & Scaling
-
-**Q: What are the resource requirements?**  
-A: Minimum 1 CPU core and 1GB RAM. For production with heavy traffic, 2+ CPU cores and 4GB+ RAM recommended.
-
-**Q: Can I run multiple instances?**  
-A: Yes, you can deploy multiple instances behind a load balancer for high availability.
-
-**Q: How much disk space does caching use?**  
-A: Default is 2 GB. Adjust the cache size from **Settings → Proxy** (writes `/config/squid_settings.env`) — 5–10 GB is reasonable for production.
-
-### Troubleshooting
-
-**Q: Services won't start - what should I check?**  
-A:
-1. Run the initialization script: `make setup`
-2. Ensure Docker and Docker Compose are installed and running
-3. Check for port conflicts: `docker compose logs`
-4. Verify volumes have correct permissions: `chmod 755 config data logs`
-5. Wait for backend health check (may take 10-15 seconds)
-6. See the comprehensive [Deployment Guide](DEPLOYMENT.md#troubleshooting) for detailed solutions
-
-**Q: Getting permission errors with config/data/logs directories?**
-A: Run the initialization script (`make setup`) or manually create directories with proper permissions:
-```bash
-mkdir -p config data logs
-chmod 755 config data logs
-```
-
-**Q: Authentication is failing between services?**
-A: Ensure you have a `.env` file with credentials set. Copy from `.env.example`:
-```bash
-cp .env.example .env
-docker compose restart
-```
-
-**Q: Why am I getting SSL certificate warnings?**  
-A: The SSL certificate needs to be installed on each client device. See [Custom SSL Certificate](#custom-ssl-certificate) section.
-
-**Q: Import is failing - what's wrong?**  
-A: Common causes:
-- Invalid format (ensure one entry per line or valid JSON)
-- Network issues (URL not accessible)
-- Authentication failure (check credentials)
-- Check logs: `docker compose logs backend`
+Go unit tests: `cd backend-go && go test ./...` and `cd waf-go && go test ./...`.
+UI tests: `cd ui && npm test`. A local pre-commit check that runs TypeScript,
+ESLint, Go vet/test, and the UI build is at `scripts/pre-commit-validate.sh`.
 
 ## Troubleshooting
 
-### Quick Fixes
+- **Backend container won't start** - check `docker compose logs backend`. The
+  most common cause is an empty/weak `BASIC_AUTH_PASSWORD` or a known/short
+  `SECRET_KEY`; both are rejected by design.
+- **Can't reach the UI** - it is HTTPS on 8443 with a self-signed cert; accept
+  the certificate, or use `https://localhost:8443` (not `http://...:8011`).
+- **Clients aren't being filtered** - confirm the device's proxy is set to
+  `:3128` and the source IP is RFC1918/localhost (other sources are denied).
+- **HTTPS isn't inspected** - that is the default; enable SSL-bump and install
+  the CA to inspect request contents.
 
-**First-Time Setup Issues?** 
-- Run the initialization script: `make setup`
-- Or manually: `mkdir -p config data logs && cp .env.example .env && docker compose up -d`
+## API
 
-**For detailed troubleshooting and step-by-step solutions, see the [Deployment Guide](DEPLOYMENT.md#troubleshooting).**
+The backend exposes a REST API (72 routes) used by the UI. A machine-readable
+listing is available at `GET /api/docs`. Authenticate with HTTP Basic auth, or
+exchange credentials at `POST /api/auth/login` for a JWT and send it as a Bearer
+token.
 
-### Common Issues
+## Architecture and deployment docs
 
-| Issue | Possible Cause | Resolution |
-|-------|---------------|------------|
-| Cannot access web UI | Port conflict or service not started | Run `make setup`, check `docker compose ps` |
-| Permission denied errors | Missing directories or wrong permissions | Run `make setup` or `mkdir -p config data logs && chmod 755 config data logs` |
-| Authentication failures | Missing .env file | Copy `.env.example` to `.env` and restart |
-| Proxy not filtering | Incorrect network configuration | Verify client proxy settings |
-| SSL warnings | Certificate not trusted | Install certificate on client devices |
-| Performance issues | Insufficient resources | Increase container resource limits |
-| Database errors | Permission issues | Check volume permissions with `ls -la data/` |
+- [DEPLOYMENT.md](DEPLOYMENT.md) - step-by-step deployment, reverse-proxy and
+  TLS setup, resource tuning.
+- [SECURITY.md](SECURITY.md) - security model and how to report issues.
+- [BENCHMARKS.md](BENCHMARKS.md) - reproducible performance and detection
+  benchmarks.
+- [CHANGELOG.md](CHANGELOG.md) - release history.
 
-### Diagnostic Tools
+## Security notes
 
-1. **Service Logs**:
-   ```bash
-   docker compose logs -f backend
-   docker compose logs -f ui
-   docker compose logs -f proxy
-   ```
-
-2. **Database Check**:
-   ```bash
-   docker compose exec backend sqlite3 /data/secure_proxy.db .tables
-   ```
-
-3. **Network Validation**:
-   ```bash
-   docker compose exec proxy ping -c 3 google.com
-   ```
-
-4. **Cache Analysis**:
-   ```bash
-   docker compose exec proxy squidclient -h localhost mgr:info
-   ```
-
-## API Documentation
-
-Secure Proxy Manager provides a RESTful API for integration and automation with support for plain text and JSON blacklist imports.
-
-**API Base URLs:**
-- Via Web UI: `https://localhost:8443/api`
-- Direct Backend Access: `http://localhost:5001/api`
-
-**Note:** When accessing the API directly through the backend (port 5001), you bypass the Web UI layer. This can be useful for automation scripts and monitoring tools.
-
-### Authentication
-
-Every protected endpoint accepts either HTTP Basic or a JWT bearer token:
-
-```bash
-# Basic auth (handy for scripts)
-AUTH_HEADER="Authorization: Basic $(printf '%s' "$USER:$PASS" | base64)"
-
-# Or exchange credentials for a JWT pair and use the access token
-TOKEN=$(curl -s -X POST https://localhost:8443/api/auth/login \
-  -H 'Content-Type: application/json' \
-  -d "{\"username\":\"$USER\",\"password\":\"$PASS\"}" | jq -r '.access_token')
-AUTH_HEADER="Authorization: Bearer $TOKEN"
-```
-
-### Blacklist Management
-
-#### Import Domain Blacklists
-
-```bash
-AUTH_HEADER="Authorization: Basic $(echo -n YOUR_USER:YOUR_PASS | base64)"
-
-# Import from URL (plain text file, one domain per line)
-curl -X POST https://localhost:8443/api/blacklists/import \
-  -H "Content-Type: application/json" \
-  -H "$AUTH_HEADER" \
-  -d '{"type": "domain", "url": "https://example.com/domain-blacklist.txt"}'
-
-# Import inline content
-curl -X POST https://localhost:8443/api/blacklists/import \
-  -H "Content-Type: application/json" \
-  -H "$AUTH_HEADER" \
-  -d '{"type": "domain", "content": "malicious.com\n*.ads.example\nbadsite.org"}'
-```
-
-**Example domain-blacklist.txt:**
-```
-malicious.com
-badsite.org
-*.ads.network
-phishing-site.net
-# Comments are ignored
-unwanted.domain
-```
-
-#### Import IP Blacklists
-
-```bash
-AUTH_HEADER="Authorization: Basic $(echo -n YOUR_USER:YOUR_PASS | base64)"
-
-# Import from URL
-curl -X POST https://localhost:8443/api/blacklists/import \
-  -H "Content-Type: application/json" \
-  -H "$AUTH_HEADER" \
-  -d '{"type": "ip", "url": "https://example.com/ip-blacklist.txt"}'
-
-# Import with CIDR notation support
-curl -X POST https://localhost:8443/api/blacklists/import \
-  -H "Content-Type: application/json" \
-  -H "$AUTH_HEADER" \
-  -d '{"type": "ip", "content": "192.168.1.100\n10.0.0.0/8\n172.16.0.0/12"}'
-```
-
-**Example ip-blacklist.txt:**
-```
-192.168.1.100
-10.0.0.5
-203.0.113.0/24
-# Malicious IP range
-198.51.100.0/24
-```
-
-#### Supported File Formats
-
-- **Plain Text**: One entry per line (most common)
-- **JSON Array**: `["entry1", "entry2"]`
-- **JSON Objects**: `[{"domain": "example.com", "description": "Blocked"}]`
-- **Comments**: Lines starting with `#` are ignored
-- **CIDR Notation**: For IP ranges (`192.168.1.0/24`)
-- **Wildcards**: For domains (`*.example.com`)
-
-### Available Endpoints
-
-#### Authentication & Session Management
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/auth/login` | POST | Validate credentials, return JWT access + refresh tokens |
-| `/api/auth/refresh` | POST | Exchange a refresh token for a fresh pair |
-| `/api/logout` | POST | Revoke the JWT used to authenticate the request |
-| `/api/change-password` | POST | Change the admin password |
-| `/api/ws-token` | GET | Issue a single-use WebSocket auth token |
-
-#### Proxy Status & Settings
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/status` | GET | Get proxy service status |
-| `/api/settings` | GET | Get all proxy settings |
-| `/api/settings/<setting_name>` | PUT | Update a specific setting |
-| `/api/settings` | POST | Bulk update settings |
-| `/health` | GET | Health check endpoint |
-| `/api/health` | GET | Health check endpoint (API prefix) |
-
-#### Blacklist and Whitelist Management
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/ip-blacklist` | GET | List all IP blacklist entries |
-| `/api/ip-blacklist` | POST | Add a single IP blacklist entry |
-| `/api/ip-blacklist/<id>` | DELETE | Delete an IP blacklist entry |
-| `/api/ip-blacklist/bulk-delete` | POST | Delete multiple IP blacklist entries |
-| `/api/ip-blacklist/clear-all` | DELETE | Remove all IP blacklist entries |
-| `/api/domain-blacklist` | GET | List all domain blacklist entries |
-| `/api/domain-blacklist` | POST | Add a single domain blacklist entry |
-| `/api/domain-blacklist/<id>` | DELETE | Delete a domain blacklist entry |
-| `/api/domain-blacklist/bulk-delete` | POST | Delete multiple domain blacklist entries |
-| `/api/domain-blacklist/clear-all` | DELETE | Remove all domain blacklist entries |
-| `/api/blacklists/import` | POST | Import blacklist from URL or inline content (`type`: `ip` or `domain`) |
-| `/api/ip-blacklist/import` | POST | Per-type import (IP) |
-| `/api/domain-blacklist/import` | POST | Per-type import (domain) |
-| `/api/blacklists/import-geo` | POST | Import geo-based IP block by country code(s) |
-| `/api/ip-whitelist` | GET | List all IP whitelist entries (bypass direct-IP block) |
-| `/api/ip-whitelist` | POST | Add an IP/network to the whitelist |
-| `/api/ip-whitelist/<id>` | DELETE | Remove an IP from the whitelist |
-| `/api/domain-whitelist` | GET | List domain whitelist entries (DNS blackhole bypass) |
-| `/api/domain-whitelist` | POST | Add a domain to the DNS whitelist |
-| `/api/domain-whitelist/<id>` | DELETE | Remove a domain from the whitelist |
-
-#### Logs & Analytics
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/logs` | GET | Get proxy access log entries (`limit` param, default 100) |
-| `/api/logs/stats` | GET | Get log statistics (total, blocked, IP block counts) |
-| `/api/logs/timeline` | GET | Traffic timeline data for the last 24h (used by dashboard chart) |
-| `/api/logs/clear` | POST | Clear all proxy logs |
-| `/api/logs/clear-old` | POST | Delete logs older than the retention period |
-| `/api/audit-log` | GET | Audit log of administrative actions |
-
-#### Intelligence & Analytics
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/analytics/shadow-it` | GET | Detect SaaS services accessed through proxy (35+ services) |
-| `/api/analytics/user-agents` | GET | Service type breakdown (Google, Microsoft, CDN, Dev...) |
-| `/api/analytics/file-extensions` | GET | File extension distribution with category grouping |
-| `/api/analytics/top-domains` | GET | Top accessed domains for cloud visualization |
-| `/api/dashboard/summary` | GET | Aggregated dashboard data in single call |
-| `/api/waf/stats` | GET | WAF engine statistics (rules, blocks, entropy) |
-| `/api/waf/categories` | GET | List WAF rule categories with toggle state |
-| `/api/waf/categories/toggle` | POST | Enable or disable a category at runtime |
-| `/api/waf/test-rule` | POST | Evaluate a regex rule against a sample request |
-| `/api/counters/reset` | POST | Reset all counters (logs, WAF, dashboard) |
-
-#### Cache Management
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/cache/statistics` | GET | Get cache performance metrics |
-| `/api/maintenance/clear-cache` | POST | Clear the Squid disk cache |
-
-#### Security
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/security/score` | GET | Get security assessment score and recommendations |
-| `/api/security/cve` | GET | CVE check for the bundled Squid version |
-| `/api/security/rate-limits` | GET | List currently rate-limited IPs |
-| `/api/security/rate-limits/<ip>` | DELETE | Remove rate limit for specific IP |
-| `/api/maintenance/check-cert-security` | GET | Inspect SSL bump certificate strength |
-| `/api/notifications/test` | POST | Send a test notification (Gotify, Telegram, webhook, Teams, SIEM) |
-
-#### Database & Maintenance
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/database/size` | GET | Get database file size |
-| `/api/database/stats` | GET | Get database statistics |
-| `/api/database/optimize` | POST | Optimize database |
-| `/api/database/export` | GET | Export database |
-| `/api/database/reset` | POST | Reset database |
-| `/api/maintenance/reload-config` | POST | Reload proxy configuration |
-| `/api/maintenance/reload-dns` | POST | Reload DNS configuration |
-| `/api/maintenance/clear-cache` | POST | Clear proxy cache |
-| `/api/maintenance/backup-config` | GET | Download configuration backup |
-| `/api/maintenance/restore-config` | POST | Restore configuration from backup |
-| `/api/maintenance/check-cert-security` | GET | Check SSL certificate security |
-| `/api/security/download-ca` | GET | Download the proxy CA certificate |
-| `/api/dns/detect` | POST | Probe a target subnet for Pi-hole or AdGuard instances |
-| `/api/internal/alert` | POST | Receives WAF block notifications (used by the WAF service) |
-
-#### API Documentation
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/docs` | GET | Interactive API documentation |
-
-### Example API Responses
-
-**Successful import:**
-```json
-{
-  "status": "success",
-  "message": "Successfully imported 150 entries (0 skipped/invalid)",
-  "data": { "added": 150, "skipped": 0 }
-}
-```
-
-**Error response:**
-```json
-{ "status": "error", "detail": "Invalid IP format: 999.999.999.999" }
-```
-
-Full interactive API documentation is available at `/api/docs` when the service is running.
-
-## Security Best Practices
-
-1. **Change default credentials** immediately after installation
-2. **Enable HTTPS** for the admin interface in production
-3. **Restrict access** to the admin interface to trusted IPs
-4. **Regular backups** of configuration and database
-5. **Monitor logs** for suspicious activity
-6. **Use strong certificates** for HTTPS filtering
-
-**Recent Security Hardening:**
-- Replaced vulnerable string interpolations in SQL queries with strict parameter binding (SQLi mitigated).
-- Implemented robust SSRF (Server-Side Request Forgery) protection on blacklist import URLs, blocking localhost and private IP scanning.
-- Memory leak and GIL bottleneck protection via replacing the WAF engine with a high-concurrency Go implementation.
-- Improved frontend resilience with strict Zod validation and Idempotency keys.
-- De-escalated Squid proxy privileges from `root` to a dedicated `proxy` user.
-
-## Future Roadmap
-
-- **WAF False Positive Management**: Exclude rules per domain with one click
-- **ASN Blocking**: Block entire Autonomous Systems by number
-- **Bloom Filter Tuning**: Auto-adjust cache TTL based on traffic patterns
-- **Federated Threat Intel**: Share anonymized threat data between instances
-- **Config Versioning**: Diff and rollback proxy/WAF configuration changes
-- **PDF analytics report**: Re-implement in Go (the UI button is wired but the backend endpoint is not yet ported)
+- The SSL-bump CA is generated per deployment at first boot and never committed;
+  treat the private key under `config/` as sensitive and never share it.
+- Set strong admin credentials. The proxy only accepts RFC1918/localhost clients
+  by default - if you expose port 3128 publicly, put it behind authentication or
+  a private network (e.g. the Tailscale sidecar).
+- Sensitive settings (webhook URLs, tokens) are encrypted at rest; JWT secrets
+  and the encryption key are generated and persisted under `data/`.
 
 ## Contributing
 
-Contributions are welcome and appreciated! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on:
-
-- Setting up your development environment
-- Coding standards and best practices
-- Testing requirements
-- Pull request process
-- Branch naming conventions
-
-Quick contribution steps:
-
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/your-feature-name`
-3. Make your changes following our coding standards
-4. Run tests to ensure everything works
-5. Commit your changes: `git commit -m 'feat: Add some feature'`
-6. Push to your fork: `git push origin feature/your-feature-name`
-7. Open a Pull Request with a clear description
-
-For more details, see [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md). Issues and pull requests are welcome.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Acknowledgements
-
-- [Squid Proxy](http://www.squid-cache.org/) for the core proxy engine
-- [Go](https://go.dev/) for the backend and WAF engine runtime
-- [chi](https://github.com/go-chi/chi) for HTTP routing
-- [React](https://react.dev/) and [Tailwind CSS](https://tailwindcss.com/) for the frontend
-- [Recharts](https://recharts.org/) for dashboard data visualization
-- [Docker](https://www.docker.com/) for containerization
-- [Claude Code](https://claude.ai/code) for AI-assisted development
-- All contributors who have helped shape this project
-
-## Support
-
-If you need help or have questions:
-
-- **Bug Reports**: [Create an issue](https://github.com/fabriziosalmi/secure-proxy-manager/issues/new) with detailed information
-- **Feature Requests**: [Open an issue](https://github.com/fabriziosalmi/secure-proxy-manager/issues/new) describing your idea
-- **Questions**: Check [existing issues](https://github.com/fabriziosalmi/secure-proxy-manager/issues) or create a new one
-- **Documentation**: Review this README and [CONTRIBUTING.md](CONTRIBUTING.md)
-
-When reporting issues, please include:
-- Your environment (OS, Docker version, etc.)
-- Steps to reproduce the problem
-- Expected vs actual behavior
-- Relevant logs from `docker compose logs`
-
----
-
-**Made by Fabrizio Salmi + Claude Code + the Secure Proxy Manager community**
+[MIT](LICENSE).

--- a/backend-go/internal/config/config.go
+++ b/backend-go/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -16,18 +17,18 @@ import (
 type Config struct {
 	// Auth / JWT
 	AdminUsername     string
-	AdminPassword     string        // plaintext only for initial / legacy auth
-	AdminPasswordHash string        // bcrypt hash loaded from DB at runtime (optional)
+	AdminPassword     string // plaintext only for initial / legacy auth
+	AdminPasswordHash string // bcrypt hash loaded from DB at runtime (optional)
 	SecretKey         string
 	JWTExpireDuration time.Duration
 	MaxAttempts       int
 	RateLimitWindow   time.Duration
 
 	// Network
-	Port           string
+	Port               string
 	CORSAllowedOrigins []string
-	ProxyHost      string
-	ProxyPort      string
+	ProxyHost          string
+	ProxyPort          string
 
 	// Filesystem
 	DatabasePath string
@@ -35,9 +36,9 @@ type Config struct {
 	LogPath      string
 
 	// Internal component URLs (for WAF/Proxy communication)
-	WAFURL       string
-	ProxyURL     string
-	GeoIPURL     string
+	WAFURL   string
+	ProxyURL string
+	GeoIPURL string
 
 	// Encryption key for sensitive settings (hex-encoded 32 bytes)
 	EncryptionKey string
@@ -74,23 +75,23 @@ func Load() *Config {
 	}
 
 	cfg := &Config{
-		AdminUsername:     username,
-		AdminPassword:     password,
-		SecretKey:         loadOrGenerateSecret(),
-		JWTExpireDuration: jwtExp,
-		MaxAttempts:       maxAttempts,
-		RateLimitWindow:   time.Duration(rateLimitSec) * time.Second,
-		Port:              envOrDefault("PORT", "5000"),
+		AdminUsername:      username,
+		AdminPassword:      password,
+		SecretKey:          loadOrGenerateSecret(),
+		JWTExpireDuration:  jwtExp,
+		MaxAttempts:        maxAttempts,
+		RateLimitWindow:    time.Duration(rateLimitSec) * time.Second,
+		Port:               envOrDefault("PORT", "5000"),
 		CORSAllowedOrigins: cleanCors,
-		ProxyHost:         envOrDefault("PROXY_HOST", "proxy"),
-		ProxyPort:         envOrDefault("PROXY_PORT", "3128"),
-		DatabasePath:      envOrDefault("DATABASE_PATH", "/data/proxy_manager.db"),
-		ConfigDir:         envOrDefault("CONFIG_DIR", "/config"),
-		LogPath:           envOrDefault("LOG_PATH", "/logs/access.log"),
-		WAFURL:            envOrDefault("WAF_URL", "http://waf:8080"),
-		ProxyURL:          envOrDefault("PROXY_URL", "http://proxy:3128"),
-		GeoIPURL:          envOrDefault("GEOIP_URL", ""), // Empty means use defaults
-		EncryptionKey:     loadOrGenerateEncKey(),
+		ProxyHost:          envOrDefault("PROXY_HOST", "proxy"),
+		ProxyPort:          envOrDefault("PROXY_PORT", "3128"),
+		DatabasePath:       envOrDefault("DATABASE_PATH", "/data/proxy_manager.db"),
+		ConfigDir:          envOrDefault("CONFIG_DIR", "/config"),
+		LogPath:            envOrDefault("LOG_PATH", "/logs/access.log"),
+		WAFURL:             envOrDefault("WAF_URL", "http://waf:8080"),
+		ProxyURL:           envOrDefault("PROXY_URL", "http://proxy:3128"),
+		GeoIPURL:           envOrDefault("GEOIP_URL", ""), // Empty means use defaults
+		EncryptionKey:      loadOrGenerateEncKey(),
 	}
 	return cfg
 }
@@ -115,6 +116,52 @@ func validatePasswordComplexity(password string) {
 	}
 	if len(password) < 8 {
 		log.Fatal().Int("length", len(password)).Msg("BASIC_AUTH_PASSWORD must be at least 8 characters")
+	}
+}
+
+// knownWeakSecrets are example/dev SECRET_KEY values shipped in docs, compose
+// files or commonly copy-pasted. A predictable JWT secret lets an attacker forge
+// admin session tokens, so we refuse to boot with one (compared case-folded).
+var knownWeakSecrets = map[string]struct{}{
+	"dev_secret_key_change_in_production": {},
+	"change_in_production":                {},
+	"changeme":                            {},
+	"change_me":                           {},
+	"secret":                              {},
+	"secret_key":                          {},
+	"your_secret_key_here":                {},
+	"please_change_me":                    {},
+	"supersecret":                         {},
+}
+
+// secretKeyStrengthError returns a non-nil error if the operator-supplied JWT
+// secret is predictable (known example value, too short, or too low entropy).
+// Split out from the fatal wrapper so the policy is unit-testable without
+// os.Exit. An empty SECRET_KEY is handled separately by loadOrGenerateSecret
+// (auto-generate), so this only runs on operator-supplied values.
+func secretKeyStrengthError(secret string) error {
+	const minLen = 32
+	if _, bad := knownWeakSecrets[strings.ToLower(strings.TrimSpace(secret))]; bad {
+		return fmt.Errorf("SECRET_KEY is a known example/default value — set a unique random secret (generate one with `openssl rand -hex 32`)")
+	}
+	if len(secret) < minLen {
+		return fmt.Errorf("SECRET_KEY is too short (%d chars) — use at least %d (`openssl rand -hex 32`)", len(secret), minLen)
+	}
+	distinct := make(map[rune]struct{}, len(secret))
+	for _, r := range secret {
+		distinct[r] = struct{}{}
+	}
+	if len(distinct) < 8 {
+		return fmt.Errorf("SECRET_KEY has too little entropy (%d distinct characters) — generate one with `openssl rand -hex 32`", len(distinct))
+	}
+	return nil
+}
+
+// validateSecretKeyStrength fails the process closed on a predictable JWT secret,
+// mirroring validatePasswordComplexity — a weak secret forges every session token.
+func validateSecretKeyStrength(secret string) {
+	if err := secretKeyStrengthError(secret); err != nil {
+		log.Fatal().Msg(err.Error())
 	}
 }
 
@@ -156,6 +203,7 @@ func loadOrGenerateEncKey() string {
 // loadOrGenerateSecret reads the JWT secret from env → file → auto-generate.
 func loadOrGenerateSecret() string {
 	if s := os.Getenv("SECRET_KEY"); s != "" {
+		validateSecretKeyStrength(s) // fail-closed on predictable secrets
 		return s
 	}
 	const jwtFile = "/data/.jwt_secret"

--- a/backend-go/internal/config/config_test.go
+++ b/backend-go/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -11,7 +12,7 @@ func TestLoad(t *testing.T) {
 	os.Setenv("BASIC_AUTH_PASSWORD", "testpass")
 	os.Setenv("PORT", "9999")
 	os.Setenv("CORS_ALLOWED_ORIGINS", "http://test.com, http://example.com")
-	
+
 	defer func() {
 		os.Unsetenv("BASIC_AUTH_USERNAME")
 		os.Unsetenv("BASIC_AUTH_PASSWORD")
@@ -48,9 +49,37 @@ func TestLoadOrGenerateSecret(t *testing.T) {
 	// Test from ENV
 	os.Setenv("SECRET_KEY", "super-secret-key-12345678901234567890")
 	defer os.Unsetenv("SECRET_KEY")
-	
+
 	s := loadOrGenerateSecret()
 	if s != "super-secret-key-12345678901234567890" {
 		t.Errorf("Expected secret from env, got %s", s)
+	}
+}
+
+func TestSecretKeyStrengthError(t *testing.T) {
+	weak := []struct {
+		name   string
+		secret string
+	}{
+		{"known default", "dev_secret_key_change_in_production"},
+		{"known default cased", "ChangeMe"},
+		{"too short", "abc123"},
+		{"low entropy repeat", strings.Repeat("a", 64)},
+		{"low entropy few chars", strings.Repeat("ab", 32)},
+	}
+	for _, tc := range weak {
+		if err := secretKeyStrengthError(tc.secret); err == nil {
+			t.Errorf("%s: expected error for %q, got nil", tc.name, tc.secret)
+		}
+	}
+
+	strong := []string{
+		"super-secret-key-12345678901234567890",
+		"f3a9c1d2e4b5968708172635445362718091a2b3c4d5e6f70819ab2c3d4e5f60", // openssl rand -hex 32
+	}
+	for _, s := range strong {
+		if err := secretKeyStrengthError(s); err != nil {
+			t.Errorf("expected %q to be accepted, got error: %v", s, err)
+		}
 	}
 }

--- a/backend-go/internal/database/db.go
+++ b/backend-go/internal/database/db.go
@@ -147,6 +147,16 @@ func Init(db *sql.DB, adminUsername, adminPasswordHash string) error {
 		_, _ = db.Exec(m) // "duplicate column" error is harmless
 	}
 
+	// Backfill unix_timestamp for rows written before it was populated, so the
+	// idx_proxy_logs_unix_ts index covers historical data and time-window
+	// analytics can range-scan on it instead of doing TEXT-date arithmetic.
+	if _, err := db.Exec(
+		`UPDATE proxy_logs SET unix_timestamp = CAST(strftime('%s', timestamp) AS INTEGER)
+		 WHERE unix_timestamp IS NULL AND timestamp IS NOT NULL`,
+	); err != nil {
+		log.Warn().Err(err).Msg("backfill unix_timestamp failed (non-fatal)")
+	}
+
 	// Default settings.
 	defaultSettings := [][]string{
 		// Proxy configuration

--- a/backend-go/internal/docker/client.go
+++ b/backend-go/internal/docker/client.go
@@ -12,10 +12,51 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
 const dockerSock = "/var/run/docker.sock"
+
+// The Docker socket is host-root-equivalent: a process that can talk to it can
+// start a privileged container and take over the host. Every call site in this
+// codebase passes a hardcoded container name and command, but we defence-in-
+// depth against a future bug (or an RCE/SSRF elsewhere) turning this client into
+// an arbitrary-container, arbitrary-command control plane. All three operations
+// are therefore constrained to fixed allowlists.
+var (
+	// allowedContainers is the set of containers the backend may control.
+	allowedContainers = map[string]struct{}{
+		"secure-proxy-manager-proxy":   {},
+		"secure-proxy-manager-proxy-1": {},
+		"secure-proxy-manager-dns-1":   {},
+	}
+
+	// allowedExecCommands is the set of argv vectors Exec may run, matched
+	// exactly (joined by NUL) so neither the binary nor any argument can be
+	// influenced by request data.
+	allowedExecCommands = map[string]struct{}{
+		execKey([]string{"squid", "-k", "purge"}):                                       {},
+		execKey([]string{"squid", "-k", "shutdown"}):                                    {},
+		execKey([]string{"squidclient", "-h", "127.0.0.1", "-p", "3128", "mgr:info"}):   {},
+		execKey([]string{"squidclient", "-h", "127.0.0.1", "-p", "3128", "mgr:menu"}):   {},
+		execKey([]string{"squidclient", "-h", "127.0.0.1", "-p", "3128", "mgr:active"}): {},
+	}
+
+	// allowedSignals limits KillContainer to the signals the backend sends.
+	allowedSignals = map[string]struct{}{
+		"HUP": {}, "TERM": {}, "INT": {},
+	}
+)
+
+func execKey(cmd []string) string { return strings.Join(cmd, "\x00") }
+
+func checkContainerAllowed(name string) error {
+	if _, ok := allowedContainers[name]; !ok {
+		return fmt.Errorf("docker: container %q is not in the control allowlist", name)
+	}
+	return nil
+}
 
 // DockerClient defines the interface for interacting with the Docker Engine API.
 type DockerClient interface {
@@ -44,6 +85,12 @@ func New() *Client {
 // KillContainer sends signal to a container via the Docker Engine API.
 // Equivalent to: docker kill --signal=<sig> <name>
 func (c *Client) KillContainer(name, signal string) error {
+	if err := checkContainerAllowed(name); err != nil {
+		return err
+	}
+	if _, ok := allowedSignals[signal]; !ok {
+		return fmt.Errorf("docker: signal %q is not in the allowlist", signal)
+	}
 	u := fmt.Sprintf("http://localhost/v1.41/containers/%s/kill?signal=%s",
 		url.PathEscape(name), url.QueryEscape(signal))
 	req, err := http.NewRequest(http.MethodPost, u, nil)
@@ -64,6 +111,9 @@ func (c *Client) KillContainer(name, signal string) error {
 // RestartContainer restarts a container via the Docker Engine API.
 // Equivalent to: docker restart <name>
 func (c *Client) RestartContainer(name string) error {
+	if err := checkContainerAllowed(name); err != nil {
+		return err
+	}
 	u := fmt.Sprintf("http://localhost/v1.41/containers/%s/restart", url.PathEscape(name))
 	req, err := http.NewRequest(http.MethodPost, u, nil)
 	if err != nil {
@@ -83,6 +133,13 @@ func (c *Client) RestartContainer(name string) error {
 // ExecContainer runs a command inside a container and returns stdout.
 // Equivalent to: docker exec <name> <cmd...>
 func (c *Client) ExecContainer(name string, cmd []string) (string, error) {
+	if err := checkContainerAllowed(name); err != nil {
+		return "", err
+	}
+	if _, ok := allowedExecCommands[execKey(cmd)]; !ok {
+		return "", fmt.Errorf("docker: exec command %v is not in the allowlist", cmd)
+	}
+
 	// Step 1: Create exec instance
 	createBody, _ := json.Marshal(map[string]any{
 		"AttachStdout": true,

--- a/backend-go/internal/docker/docker_test.go
+++ b/backend-go/internal/docker/docker_test.go
@@ -61,7 +61,7 @@ func TestClient_KillContainer(t *testing.T) {
 				hc: &http.Client{Transport: mrt},
 			}
 
-			err := client.KillContainer("test-container", "HUP")
+			err := client.KillContainer("secure-proxy-manager-proxy-1", "HUP")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("KillContainer() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -82,6 +82,34 @@ func TestClient_KillContainer_RequestError(t *testing.T) {
 	err := client.KillContainer("test-container", "HUP")
 	if err == nil {
 		t.Error("Expected error from network failure, got nil")
+	}
+}
+
+// failingTransport must never be reached when the allowlist rejects a call.
+type failingTransport struct{ t *testing.T }
+
+func (f *failingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	f.t.Fatal("allowlist should have rejected the call before any HTTP request")
+	return nil, nil
+}
+
+func TestClient_Allowlist(t *testing.T) {
+	client := &Client{hc: &http.Client{Transport: &failingTransport{t}}}
+
+	if err := client.KillContainer("evil-container", "HUP"); err == nil {
+		t.Error("KillContainer: expected rejection of non-allowlisted container")
+	}
+	if err := client.KillContainer("secure-proxy-manager-dns-1", "KILL"); err == nil {
+		t.Error("KillContainer: expected rejection of non-allowlisted signal")
+	}
+	if err := client.RestartContainer("evil-container"); err == nil {
+		t.Error("RestartContainer: expected rejection of non-allowlisted container")
+	}
+	if _, err := client.ExecContainer("secure-proxy-manager-proxy", []string{"sh", "-c", "rm -rf /"}); err == nil {
+		t.Error("ExecContainer: expected rejection of non-allowlisted command")
+	}
+	if _, err := client.ExecContainer("evil-container", []string{"squid", "-k", "purge"}); err == nil {
+		t.Error("ExecContainer: expected rejection of non-allowlisted container")
 	}
 }
 

--- a/backend-go/internal/handlers/helpers.go
+++ b/backend-go/internal/handlers/helpers.go
@@ -41,8 +41,50 @@ func isValidCIDR(s string) bool {
 	return err == nil
 }
 
+// internallyManagedSettings are written by the application itself (not the
+// operator) and must never be set through the generic bulk-update or
+// restore-config paths, where a crafted payload could otherwise rewrite trusted
+// internal state (e.g. clearing the "admin password changed" flag).
+var internallyManagedSettings = map[string]bool{
+	"default_password_changed": true,
+}
+
+// isWritableSettingKey reports whether a settings key may be written through the
+// bulk-update / restore-config endpoints: it must match the key-name convention,
+// be within the length bound, and not be an internally-managed key.
+func isWritableSettingKey(key string) bool {
+	return len(key) <= 100 && validKeyRE.MatchString(key) && !internallyManagedSettings[key]
+}
+
+// isBlockedIP reports whether an IP must not be reached by server-side fetches:
+// private, loopback, link-local, unspecified, multicast, 0.0.0.0/8 or the
+// 100.64.0.0/10 CGNAT range (commonly fronting internal infra / metadata).
+func isBlockedIP(ip net.IP) bool {
+	a, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return true
+	}
+	a = a.Unmap()
+	if a.IsPrivate() || a.IsLoopback() || a.IsLinkLocalUnicast() ||
+		a.IsLinkLocalMulticast() || a.IsUnspecified() || a.IsMulticast() {
+		return true
+	}
+	if a.Is4() {
+		b := a.As4()
+		if b[0] == 0 { // 0.0.0.0/8
+			return true
+		}
+		if b[0] == 100 && b[1] >= 64 && b[1] <= 127 { // 100.64.0.0/10 CGNAT
+			return true
+		}
+	}
+	return false
+}
+
 // isSSRFTarget resolves the hostname in rawURL and returns true if ANY resolved
-// IP is private, loopback, link-local, or otherwise non-routable.
+// IP is non-routable. This is the early pre-flight check; the actual fetch is
+// additionally guarded at dial time by ssrfSafeClient (see below), so a DNS
+// answer that changes between this check and the dial cannot bypass protection.
 func isSSRFTarget(rawURL string) (bool, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -60,40 +102,51 @@ func isSSRFTarget(rawURL string) (bool, error) {
 		return true, fmt.Errorf("cannot resolve hostname: %w", err)
 	}
 	for _, addr := range addrs {
-		ip, err := netip.ParseAddr(addr)
-		if err != nil {
-			continue
-		}
-		if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
-			ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+		if ip := net.ParseIP(addr); ip != nil && isBlockedIP(ip) {
 			return true, nil
-		}
-		// Block 0.0.0.0/8
-		if ip.Is4() {
-			a := ip.As4()
-			if a[0] == 0 {
-				return true, nil
-			}
 		}
 	}
 	return false, nil
 }
 
-// ssrfSafeClient returns an HTTP client that pins DNS resolution to the
-// validated IPs, preventing DNS rebinding attacks.
-func ssrfSafeClient(hostname string) *http.Client {
-	addrs, err := net.LookupHost(hostname)
-	if err != nil || len(addrs) == 0 {
-		return &http.Client{Timeout: 60 * time.Second}
-	}
-	pinnedAddr := addrs[0]
+// ssrfSafeClient returns an HTTP client hardened against SSRF. Unlike a one-shot
+// pre-check, it validates the destination IP AT DIAL TIME — the IP it validates
+// is the exact IP it connects to — which closes the DNS-rebinding TOCTOU window
+// between resolution and connection. It also re-validates every redirect hop, so
+// a 30x to http://169.254.169.254/ (or any internal host) is refused rather than
+// followed.
+func ssrfSafeClient() *http.Client {
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
 	return &http.Client{
 		Timeout: 60 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("stopped after 5 redirects")
+			}
+			if ssrf, err := isSSRFTarget(req.URL.String()); err != nil || ssrf {
+				return fmt.Errorf("redirect to disallowed target %q", req.URL.Host)
+			}
+			return nil
+		},
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				// Replace hostname with pinned IP, keep port
-				_, port, _ := net.SplitHostPort(addr)
-				return (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, network, net.JoinHostPort(pinnedAddr, port))
+				host, port, err := net.SplitHostPort(addr)
+				if err != nil {
+					return nil, err
+				}
+				ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+				if err != nil {
+					return nil, err
+				}
+				if len(ips) == 0 {
+					return nil, fmt.Errorf("no addresses for %q", host)
+				}
+				for _, ipa := range ips {
+					if isBlockedIP(ipa.IP) {
+						return nil, fmt.Errorf("blocked address %s for host %q", ipa.IP, host)
+					}
+				}
+				return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
 			},
 		},
 	}
@@ -115,13 +168,10 @@ func downloadWithRetry(rawURL string, maxBytes int64) ([]byte, error) {
 }
 
 func downloadOnce(rawURL string, maxBytes int64) ([]byte, error) {
-	// Use SSRF-safe client that pins DNS to prevent rebinding
-	u, _ := url.Parse(rawURL)
-	hostname := ""
-	if u != nil {
-		hostname = u.Hostname()
-	}
-	client := ssrfSafeClient(hostname)
+	// SSRF-safe client validates the destination IP at dial time and on every
+	// redirect, so DNS rebinding between the pre-check and the fetch cannot reach
+	// internal addresses.
+	client := ssrfSafeClient()
 	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, err
@@ -169,7 +219,9 @@ func readAll(r interface{ Read([]byte) (int, error) }) ([]byte, error) {
 }
 
 // ioReader wraps a minimal Read interface into io.Reader for bytes.Buffer.ReadFrom.
-type ioReader struct{ r interface{ Read([]byte) (int, error) } }
+type ioReader struct {
+	r interface{ Read([]byte) (int, error) }
+}
 
 func (w ioReader) Read(p []byte) (int, error) { return w.r.Read(p) }
 

--- a/backend-go/internal/handlers/helpers_test.go
+++ b/backend-go/internal/handlers/helpers_test.go
@@ -1,8 +1,44 @@
 package handlers
 
 import (
+	"net"
 	"testing"
 )
+
+func TestIsBlockedIP(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1", "::1", "10.0.0.1", "192.168.1.1", "172.16.0.1",
+		"169.254.169.254",                          // cloud metadata
+		"0.0.0.0", "100.64.0.1", "100.127.255.255", // CGNAT
+		"224.0.0.1", "fe80::1", "fc00::1",
+	}
+	for _, s := range blocked {
+		if ip := net.ParseIP(s); ip == nil || !isBlockedIP(ip) {
+			t.Errorf("isBlockedIP(%q) = false, want true", s)
+		}
+	}
+	allowed := []string{"8.8.8.8", "1.1.1.1", "93.184.216.34", "100.63.255.255", "100.128.0.1", "2606:4700:4700::1111"}
+	for _, s := range allowed {
+		if ip := net.ParseIP(s); ip == nil || isBlockedIP(ip) {
+			t.Errorf("isBlockedIP(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestIsWritableSettingKey(t *testing.T) {
+	bad := []string{"default_password_changed", "has space", "semi;colon", "", "../etc"}
+	for _, k := range bad {
+		if isWritableSettingKey(k) {
+			t.Errorf("isWritableSettingKey(%q) = true, want false", k)
+		}
+	}
+	good := []string{"enable_waf", "webhook_url", "proxy_port", "enable_safesearch"}
+	for _, k := range good {
+		if !isWritableSettingKey(k) {
+			t.Errorf("isWritableSettingKey(%q) = false, want true", k)
+		}
+	}
+}
 
 func TestHelpers_IsValidCIDR(t *testing.T) {
 	cases := []struct {

--- a/backend-go/internal/handlers/maintenance.go
+++ b/backend-go/internal/handlers/maintenance.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/config"
+	appcrypto "github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/crypto"
 	"github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/database"
 	"github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/docker"
 	"github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/middleware"
@@ -62,14 +63,31 @@ func (h *MaintenanceHandlers) RestoreConfig(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusBadRequest, "no configuration data provided")
 		return
 	}
+	restored := 0
 	for k, v := range body.Config {
-		h.db.Exec( //nolint:errcheck
+		// Same guard as BulkUpdate: only known-safe, writable keys; reject
+		// internally-managed state and non-conforming key names. (Previously this
+		// path upserted ANY key/value with no validation — a mass-assignment hole.)
+		if !isWritableSettingKey(k) || len(v) > 10000 {
+			log.Warn().Str("key", k).Msg("RestoreConfig: skipping invalid or protected key")
+			continue
+		}
+		val := v
+		if appcrypto.IsSensitive(k) && val != "" {
+			if enc, err := appcrypto.Encrypt(val, h.cfg.EncryptionKey); err == nil {
+				val = enc
+			}
+		}
+		if _, err := h.db.Exec(
 			"INSERT INTO settings(setting_name,setting_value) VALUES(?,?) ON CONFLICT(setting_name) DO UPDATE SET setting_value=excluded.setting_value",
-			k, v,
-		)
+			k, val,
+		); err != nil {
+			log.Error().Str("key", k).Err(err).Msg("RestoreConfig: failed to save setting")
+		}
+		restored++
 	}
 	username, _ := r.Context().Value(middleware.CtxUsername).(string)
-	database.Audit(h.db, username, "restore_config", "", fmt.Sprintf("%d settings restored", len(body.Config)))
+	database.Audit(h.db, username, "restore_config", "", fmt.Sprintf("%d settings restored", restored))
 	writeJSON(w, http.StatusOK, map[string]string{"status": "success", "message": "Configuration restored successfully"})
 }
 

--- a/backend-go/internal/handlers/settings.go
+++ b/backend-go/internal/handlers/settings.go
@@ -121,9 +121,10 @@ func (h *SettingsHandlers) BulkUpdate(w http.ResponseWriter, r *http.Request) {
 		database.Audit(h.db, user, "update_settings", strings.Join(keys, ","), "")
 	}
 	for k, v := range body {
-		// Validate key: max 100 chars, alphanumeric+underscore only (matches DB convention)
-		if len(k) > 100 || len(v) > 10000 || !validKeyRE.MatchString(k) {
-			log.Warn().Str("key", k).Msg("BulkUpdate: skipping invalid key")
+		// Only known-safe, writable keys may be set (rejects internally-managed
+		// state like default_password_changed and any non-conforming key name).
+		if !isWritableSettingKey(k) || len(v) > 10000 {
+			log.Warn().Str("key", k).Msg("BulkUpdate: skipping invalid or protected key")
 			continue
 		}
 		val := v

--- a/backend-go/internal/workers/log_tailer.go
+++ b/backend-go/internal/workers/log_tailer.go
@@ -21,7 +21,9 @@ import (
 // It also broadcasts a JSON representation to the WebSocket hub.
 func StartLogTailer(ctx context.Context, db *sql.DB, logPath string, hub *websocket.Hub) {
 	go func() {
-		var offset int64
+		// Restore the persisted byte offset so a backend restart does not re-read
+		// the whole file from the start and re-insert every still-present line.
+		offset := readOffset(logPath)
 		ticker := time.NewTicker(500 * time.Millisecond)
 		defer ticker.Stop()
 		for {
@@ -41,7 +43,7 @@ func StartLogTailer(ctx context.Context, db *sql.DB, logPath string, hub *websoc
 				f.Close()
 				continue
 			}
-			// Detect log rotation.
+			// Detect log rotation / truncation.
 			if fi.Size() < offset {
 				offset = 0
 			}
@@ -55,16 +57,28 @@ func StartLogTailer(ctx context.Context, db *sql.DB, logPath string, hub *websoc
 			}
 			scanner := bufio.NewScanner(f)
 			scanner.Buffer(make([]byte, 64*1024), 256*1024) // 64KB default, 256KB max line
+			batch := make([]map[string]any, 0, 256)
 			for scanner.Scan() {
 				line := strings.TrimSpace(scanner.Text())
 				if line == "" {
 					continue
 				}
-				entry := parseSquidLine(line)
-				if entry == nil {
-					continue
+				if entry := parseSquidLine(line); entry != nil {
+					batch = append(batch, entry)
 				}
-				insertLogEntry(db, entry)
+			}
+			newOffset, seekErr := f.Seek(0, io.SeekCurrent)
+			f.Close()
+
+			// Insert the whole tick in one transaction. If it fails, leave the
+			// offset where it was and retry next tick rather than silently
+			// dropping rows (and advancing past them).
+			if err := insertLogBatch(db, batch); err != nil {
+				log.Warn().Err(err).Int("lines", len(batch)).Msg("log tailer: batch insert failed, will retry")
+				continue
+			}
+			// Broadcast only committed rows, so a retry does not double-emit.
+			for _, entry := range batch {
 				if msg, err := json.Marshal(entry); err == nil {
 					select {
 					case hub.Broadcast <- msg:
@@ -72,17 +86,42 @@ func StartLogTailer(ctx context.Context, db *sql.DB, logPath string, hub *websoc
 					}
 				}
 			}
-			// Update offset to current file position.
-			newOffset, err := f.Seek(0, io.SeekCurrent)
-			f.Close()
-			if err == nil {
+
+			if seekErr == nil {
 				offset = newOffset
 			} else {
 				offset = fi.Size()
 			}
+			writeOffset(logPath, offset)
 		}
 	}()
 	log.Info().Str("path", logPath).Msg("log tailer started")
+}
+
+// offsetPath returns the sidecar file that persists the tail position.
+func offsetPath(logPath string) string { return logPath + ".pos" }
+
+func readOffset(logPath string) int64 {
+	data, err := os.ReadFile(offsetPath(logPath)) // #nosec G304 — derived from configured log path
+	if err != nil {
+		return 0
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+func writeOffset(logPath string, offset int64) {
+	tmp := offsetPath(logPath) + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strconv.FormatInt(offset, 10)), 0o600); err != nil {
+		log.Warn().Err(err).Msg("log tailer: cannot persist offset (will re-read on restart)")
+		return
+	}
+	if err := os.Rename(tmp, offsetPath(logPath)); err != nil {
+		log.Warn().Err(err).Msg("log tailer: cannot move offset file into place")
+	}
 }
 
 // squid native access log format:
@@ -125,25 +164,45 @@ func parseSquidLine(line string) map[string]any {
 	statusStr := action + "/" + statusCode
 
 	return map[string]any{
-		"timestamp":   timestamp,
-		"client_ip":   clientIP,
-		"source_ip":   clientIP, // kept for DB insert compatibility
-		"method":      method,
-		"destination": destination,
-		"status":      statusStr,
-		"bytes":       bytesInt,
-		"elapsed_ms":  elapsed,
+		"timestamp":      timestamp,
+		"unix_timestamp": unixSec,
+		"client_ip":      clientIP,
+		"source_ip":      clientIP, // kept for DB insert compatibility
+		"method":         method,
+		"destination":    destination,
+		"status":         statusStr,
+		"bytes":          bytesInt,
+		"elapsed_ms":     elapsed,
 	}
 }
 
-func insertLogEntry(db *sql.DB, entry map[string]any) {
-	_, err := db.Exec(
-		`INSERT INTO proxy_logs(timestamp, source_ip, method, destination, status, bytes)
-		 VALUES(?, ?, ?, ?, ?, ?)`,
-		entry["timestamp"], entry["source_ip"], entry["method"],
-		entry["destination"], entry["status"], entry["bytes"],
-	)
-	if err != nil {
-		log.Debug().Err(err).Msg("insert log entry failed")
+// insertLogBatch inserts a tick's worth of entries in a single transaction.
+// Populating unix_timestamp (and elapsed_ms) is what makes idx_proxy_logs_unix_ts
+// usable for time-window analytics — both columns were previously never written.
+func insertLogBatch(db *sql.DB, entries []map[string]any) error {
+	if len(entries) == 0 {
+		return nil
 	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.Prepare(
+		`INSERT INTO proxy_logs(timestamp, unix_timestamp, source_ip, method, destination, status, bytes, elapsed_ms)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+	for _, e := range entries {
+		if _, err := stmt.Exec(
+			e["timestamp"], e["unix_timestamp"], e["source_ip"], e["method"],
+			e["destination"], e["status"], e["bytes"], e["elapsed_ms"],
+		); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
 }

--- a/backend-go/internal/workers/workers_test.go
+++ b/backend-go/internal/workers/workers_test.go
@@ -131,28 +131,54 @@ func TestCheckUpdate(t *testing.T) {
 	check(ts3.URL)
 }
 
-func TestInsertLogEntry(t *testing.T) {
+func TestInsertLogBatch(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	// 1. Success
-	entry := map[string]any{
-		"timestamp":   "2024-04-02T10:00:00Z",
-		"source_ip":   "192.168.1.1",
-		"method":      "GET",
-		"destination": "http://example.com",
-		"status":      "TCP_MISS/200",
-		"bytes":       1024,
+	batch := []map[string]any{
+		{
+			"timestamp":      "2024-04-02T10:00:00Z",
+			"unix_timestamp": int64(1712052000),
+			"source_ip":      "192.168.1.1",
+			"method":         "GET",
+			"destination":    "http://example.com",
+			"status":         "TCP_MISS/200",
+			"bytes":          1024,
+			"elapsed_ms":     12,
+		},
+		{"source_ip": "1.2.3.4"}, // partial map — must not break the batch
 	}
-	insertLogEntry(db, entry)
-
-	// 2. Missing fields (coverage for partial maps)
-	insertLogEntry(db, map[string]any{"source_ip": "1.2.3.4"})
+	if err := insertLogBatch(db, batch); err != nil {
+		t.Fatalf("insertLogBatch: %v", err)
+	}
 
 	var count int
 	_ = db.QueryRow("SELECT COUNT(*) FROM proxy_logs").Scan(&count)
 	if count != 2 {
 		t.Errorf("Expected 2 log entries, got %d", count)
+	}
+	// unix_timestamp must now be populated (the index depends on it).
+	var withUnix int
+	_ = db.QueryRow("SELECT COUNT(*) FROM proxy_logs WHERE unix_timestamp = 1712052000").Scan(&withUnix)
+	if withUnix != 1 {
+		t.Errorf("Expected unix_timestamp to be populated, got %d rows", withUnix)
+	}
+
+	// Empty batch is a no-op.
+	if err := insertLogBatch(db, nil); err != nil {
+		t.Errorf("insertLogBatch(nil): %v", err)
+	}
+}
+
+func TestLogOffsetRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	logPath := dir + "/access.log"
+	if got := readOffset(logPath); got != 0 {
+		t.Errorf("readOffset with no file = %d, want 0", got)
+	}
+	writeOffset(logPath, 4096)
+	if got := readOffset(logPath); got != 4096 {
+		t.Errorf("readOffset after write = %d, want 4096", got)
 	}
 }
 

--- a/proxy/startup.sh
+++ b/proxy/startup.sh
@@ -83,6 +83,22 @@ chmod 750 /config/ssl_db
 
 # ── SSL certificates ────────────────────────────────────────────────────────
 
+# Reject the CA private key that was historically committed to this repository.
+# Any deployment still carrying it shares one public keypair with every other
+# user of the project, so anyone with the repo could forge certificates and MITM
+# all SSL-bumped TLS. If we detect that exact keypair (matched by modulus, so it
+# survives PEM re-encoding), delete it and the cert DB it signed so a fresh,
+# unique CA is generated below.
+KNOWN_BAD_KEY_MODULUS_SHA256="b3443bfd0d20cec31e7a87eb77d7ebd6864253037091c69bf1d069368e089c31"
+if [ -f /config/ssl_key.pem ]; then
+    current_modulus_sha256="$(openssl rsa -in /config/ssl_key.pem -noout -modulus 2>/dev/null | openssl sha256 2>/dev/null | awk '{print $NF}')"
+    if [ "$current_modulus_sha256" = "$KNOWN_BAD_KEY_MODULUS_SHA256" ]; then
+        echo "SECURITY: detected the known-compromised committed CA key — deleting and regenerating a unique CA." >&2
+        rm -f /config/ssl_key.pem /config/ssl_cert.pem
+        rm -rf /config/ssl_db/* 2>/dev/null || true
+    fi
+fi
+
 if [ ! -f /config/ssl_cert.pem ] || [ ! -f /config/ssl_key.pem ]; then
     echo "Generating SSL certificates for HTTPS filtering..."
     openssl genrsa -out /config/ssl_key.pem 2048

--- a/scripts/pre-commit-validate.sh
+++ b/scripts/pre-commit-validate.sh
@@ -2,7 +2,7 @@
 # pre-commit-validate.sh — fast local validation before committing
 #
 # Runs without Docker (uses local toolchains).
-# Checks: TypeScript types, ESLint, Python syntax, unit tests.
+# Checks: TypeScript types, ESLint, Go format/vet/tests, UI build.
 #
 # Usage:
 #   ./scripts/pre-commit-validate.sh
@@ -58,44 +58,52 @@ else
   fi
 fi
 
-# ── 3. Python syntax check ────────────────────────────────────────────────────
+# ── 3. Go format & vet ────────────────────────────────────────────────────────
 
-step_start "Python syntax check (py_compile)"
-PY_FILES=(
-  "${REPO_ROOT}/backend/app/main.py"
-)
-
-PY_OK=true
-for f in "${PY_FILES[@]}"; do
-  if python3 -m py_compile "$f" 2>&1; then
-    echo "    OK: $f"
-  else
-    echo -e "  ${RED}FAIL: $f${NC}"
-    PY_OK=false
+step_start "Go format & vet (backend-go, waf-go)"
+# gofmt drift is reported as a warning (the tree has pre-existing drift that CI
+# does not gate on); go vet is the hard gate. Run with --fix to auto-format.
+GO_OK=true
+for mod in backend-go waf-go; do
+  dir="${REPO_ROOT}/${mod}"
+  [ -d "$dir" ] || continue
+  unformatted="$(cd "$dir" && gofmt -l . 2>/dev/null || true)"
+  if [ -n "$unformatted" ]; then
+    if [ "$FIX_MODE" = true ]; then
+      (cd "$dir" && gofmt -w .)
+      echo "    fixed formatting in ${mod}"
+    else
+      step_warn "${mod} not gofmt-clean (run with --fix): $(echo "$unformatted" | tr '\n' ' ')"
+    fi
+  fi
+  if ! (cd "$dir" && go vet ./... 2>&1); then
+    echo -e "  ${RED}FAIL: go vet in ${mod}${NC}"
+    GO_OK=false
   fi
 done
 
-if $PY_OK; then
-  step_ok "Python: no syntax errors"
+if $GO_OK; then
+  step_ok "Go: go vet passed"
 else
-  step_fail "Python: syntax errors found"
+  step_fail "Go: go vet issues found"
 fi
 
-# ── 4. Python unit tests ──────────────────────────────────────────────────────
+# ── 4. Go unit tests ──────────────────────────────────────────────────────────
 
-step_start "Python unit tests (pytest)"
-PYTEST_TARGETS=(
-  "${REPO_ROOT}/tests/test_imports.py"
-)
+step_start "Go unit tests (go test ./...)"
+GOTEST_OK=true
+for mod in backend-go waf-go; do
+  dir="${REPO_ROOT}/${mod}"
+  [ -d "$dir" ] || continue
+  if ! (cd "$dir" && go test ./... 2>&1); then
+    GOTEST_OK=false
+  fi
+done
 
-# Add test_security_improvements.py if it exists and doesn't need running backend
-EXTRA="${REPO_ROOT}/tests/test_security_improvements.py"
-[ -f "$EXTRA" ] && PYTEST_TARGETS+=("$EXTRA")
-
-if python3 -m pytest "${PYTEST_TARGETS[@]}" -v --tb=short 2>&1; then
-  step_ok "Python unit tests: all passed"
+if $GOTEST_OK; then
+  step_ok "Go unit tests: all passed"
 else
-  step_fail "Python unit tests: failures detected"
+  step_fail "Go unit tests: failures detected"
 fi
 
 # ── 5. UI build smoke-test ────────────────────────────────────────────────────

--- a/ui/src/components/SetupWizard.tsx
+++ b/ui/src/components/SetupWizard.tsx
@@ -131,7 +131,21 @@ export function SetupWizard({ onComplete }: Props) {
       const settings = mapToPreset(env, devices, strict);
       settings.wizard_completed = 'true';
       await api.post('settings', settings);
-      toast.success('Setup complete! Your proxy is configured.', { duration: 5000, icon: '🚀' });
+      // Saving only writes the toggle files; they take effect when startup.sh
+      // regenerates squid.conf, which happens on a proxy reload. Without this the
+      // wizard's "Setup complete" was misleading — nothing was actually applied.
+      // Fire-and-forget (mirrors Settings.tsx) so we don't block the wizard on
+      // the proxy restart; the toast reports progress in the background.
+      toast.promise(
+        api.post('maintenance/reload-config', {}, {
+          headers: { 'Idempotency-Key': `wizard-reload-${Date.now()}` },
+        }),
+        {
+          loading: 'Applying your configuration to the proxy…',
+          success: 'Setup complete — your proxy is live with these settings! 🚀',
+          error: 'Saved, but auto-apply failed — use Settings → Maintenance → Reload config.',
+        }
+      );
       onComplete();
     } catch {
       toast.error('Failed to save configuration');

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -13,6 +13,15 @@ export default defineConfig({
     }
   },
   build: {
+    modulePreload: {
+      // recharts (vendor-charts, ~110KB gzip) is only used by the lazy Dashboard
+      // and ThreatIntel routes. Vite would otherwise <link rel=modulepreload> it
+      // from the entry HTML, pulling it onto EVERY first paint (Logs, Settings,
+      // Audit…) and defeating the lazy boundary. Drop it from the preload set so
+      // those routes fetch it on demand; the chunk stays shared and cacheable.
+      resolveDependencies: (_filename: string, deps: string[]) =>
+        deps.filter((dep) => !dep.includes('vendor-charts')),
+    },
     rollupOptions: {
       output: {
         manualChunks(id) {

--- a/waf-go/main.go
+++ b/waf-go/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,6 +30,13 @@ const (
 
 var (
 	blockThreshold = 10 // Configurable via WAF_BLOCK_THRESHOLD env
+
+	// wafFailOpen controls behaviour when a REQMOD handler panics. Default is
+	// fail-CLOSED (block the request) — a handler that crashed cannot vouch for
+	// traffic. Operators who prefer availability over inspection can set
+	// WAF_FAIL_OPEN=1 to let such requests through unmodified.
+	wafFailOpen = false
+
 	tarPitDelay    = 10 * time.Second
 	ipBlockTracker = make(map[string][]time.Time)
 	trackerMutex   sync.Mutex
@@ -149,6 +157,11 @@ func init() {
 			blockThreshold = v
 		}
 	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("WAF_FAIL_OPEN"))) {
+	case "1", "true", "yes", "on":
+		wafFailOpen = true
+		log.Printf("WAF_FAIL_OPEN=1 — REQMOD handler panics will ALLOW traffic (availability over security)\n")
+	}
 	// Load disabled categories from env (comma-separated)
 	if disabled := os.Getenv("WAF_DISABLED_CATEGORIES"); disabled != "" {
 		for _, cat := range strings.Split(disabled, ",") {
@@ -216,6 +229,24 @@ func notifyBackend(data map[string]interface{}) {
 
 // ── ICAP handlers ───────────────────────────────────────────────────────────
 
+// recoverICAP turns a handler panic into a deterministic ICAP response instead
+// of a dropped connection (whose effect depends on Squid's bypass setting and
+// is typically fail-OPEN). For REQMOD it fails CLOSED by default — a crashed
+// handler cannot certify the request as clean — unless WAF_FAIL_OPEN is set.
+// RESPMOD failures allow the response through (blocking responses on an internal
+// error is riskier than letting them pass). It is invoked via defer, so it only
+// fires before a normal WriteHeader has run.
+func recoverICAP(w icap.ResponseWriter, method string) {
+	if r := recover(); r != nil {
+		log.Printf("PANIC in %s handler: %v\n%s", method, r, debug.Stack())
+		if method == "REQMOD" && !wafFailOpen {
+			sendBlockResponse(w, "WAF_INTERNAL_ERROR", blockThreshold)
+			return
+		}
+		w.WriteHeader(204, nil, false)
+	}
+}
+
 func handleOptions(w icap.ResponseWriter, req *icap.Request) {
 	w.Header().Set("Methods", "REQMOD, RESPMOD")
 	w.Header().Set("Service", "SecureProxy-WAF-2.0")
@@ -246,7 +277,14 @@ func handleReqmod(w icap.ResponseWriter, req *icap.Request) {
 	}
 
 	// ── Safe URL Cache: skip regex scan for known-clean URLs ────────────
-	if safeCache.IsSafe(rawURL) {
+	// Only short-circuit idempotent, body-less methods, and scope the cache key
+	// by method. A clean GET must never vouch for a POST to the same URL — that
+	// request carries an attacker-controlled body and headers we have not seen
+	// (the previous rawURL-only key let a benign GET poison the cache so a later
+	// malicious POST skipped ALL inspection).
+	cacheable := req.Request.Method == http.MethodGet || req.Request.Method == http.MethodHead
+	cacheKey := req.Request.Method + "\x00" + rawURL
+	if cacheable && safeCache.IsSafe(cacheKey) {
 		w.WriteHeader(204, nil, false)
 		return
 	}
@@ -283,7 +321,7 @@ func handleReqmod(w icap.ResponseWriter, req *icap.Request) {
 	var bodySize int
 	if score < blockThreshold && req.Request.Body != nil {
 		ct := req.Request.Header.Get("Content-Type")
-		if isTextContent(ct) {
+		if shouldInspectBody(ct) {
 			bodyBytes, readErr := io.ReadAll(io.LimitReader(req.Request.Body, maxBodyInspectSize))
 			if readErr == nil && len(bodyBytes) > 0 {
 				bodyStr = normalizeInput(string(bodyBytes))
@@ -488,8 +526,12 @@ func handleReqmod(w icap.ResponseWriter, req *icap.Request) {
 		return
 	}
 
-	// URL passed all checks — mark as safe for future requests
-	safeCache.MarkSafe(rawURL)
+	// URL passed all checks — mark as safe for future requests. Only cache a
+	// clean verdict for body-less idempotent methods where no body was inspected,
+	// so a pass can never authorize a later request that carries a body.
+	if cacheable && bodySize == 0 {
+		safeCache.MarkSafe(cacheKey)
+	}
 	w.WriteHeader(204, nil, false)
 }
 
@@ -596,8 +638,10 @@ func main() {
 		case "OPTIONS":
 			handleOptions(w, req)
 		case "REQMOD":
+			defer recoverICAP(w, "REQMOD")
 			handleReqmod(w, req)
 		case "RESPMOD":
+			defer recoverICAP(w, "RESPMOD")
 			handleRespmod(w, req)
 		default:
 			w.WriteHeader(405, nil, false)
@@ -665,7 +709,7 @@ func main() {
 	go func() {
 		h := &MgmtHandlers{}
 		healthMux := http.NewServeMux()
-		healthMux.HandleFunc("/health", h.HealthHandler) // unauthenticated — used by Docker healthcheck
+		healthMux.HandleFunc("/health", h.HealthHandler)   // unauthenticated — used by Docker healthcheck
 		healthMux.HandleFunc("/metrics", h.MetricsHandler) // unauthenticated — Prometheus exposition (no sensitive data)
 		healthMux.HandleFunc("/stats", mgmtAuthMiddleware(h.StatsHandler))
 		healthMux.HandleFunc("/reset", mgmtAuthMiddleware(h.ResetHandler))

--- a/waf-go/normalization_test.go
+++ b/waf-go/normalization_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -55,6 +56,63 @@ func TestIsTextContent(t *testing.T) {
 	for _, tt := range tests {
 		if got := isTextContent(tt.ct); got != tt.want {
 			t.Errorf("isTextContent(%q) = %v, want %v", tt.ct, got, tt.want)
+		}
+	}
+}
+
+func TestPercentDecodeTolerant(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"%41%42%43", "ABC"},
+		{"a+b", "a b"},
+		{"nothing-here", "nothing-here"},
+		{"%2e%2e%2f", "../"},
+		// A single malformed escape must NOT abort decoding of the rest.
+		{"%3Cscript%3E%ZZ", "<script>%ZZ"},
+		{"%ZZ", "%ZZ"},
+		{"trailing%", "trailing%"},
+		{"half%4", "half%4"},
+	}
+	for _, tt := range tests {
+		if got := percentDecodeTolerant(tt.in); got != tt.want {
+			t.Errorf("percentDecodeTolerant(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestNormalizeDefeatsInvalidEscapeBypass guards the regression where a single
+// invalid percent-token disabled all decoding, letting an encoded payload slip
+// through unscanned.
+func TestNormalizeDefeatsInvalidEscapeBypass(t *testing.T) {
+	got := normalizeInput("/?x=%3Cscript%3Ealert(1)%3C/script%3E%ZZ")
+	if !strings.Contains(got, "<script>") {
+		t.Fatalf("expected decoded <script> in %q — invalid-escape bypass not closed", got)
+	}
+	if _, score := matchRulesScored(got); score == 0 {
+		t.Errorf("expected the decoded payload to score > 0, got 0 (input still evades rules)")
+	}
+}
+
+func TestShouldInspectBody(t *testing.T) {
+	tests := []struct {
+		ct   string
+		want bool
+	}{
+		{"application/octet-stream", true}, // must NOT be skippable
+		{"", true},
+		{"application/json", true},
+		{"text/html", true},
+		{"application/zip", true},
+		{"image/png", false},
+		{"video/mp4", false},
+		{"font/woff2", false},
+		{"AUDIO/mpeg", false},
+	}
+	for _, tt := range tests {
+		if got := shouldInspectBody(tt.ct); got != tt.want {
+			t.Errorf("shouldInspectBody(%q) = %v, want %v", tt.ct, got, tt.want)
 		}
 	}
 }

--- a/waf-go/normalize.go
+++ b/waf-go/normalize.go
@@ -3,7 +3,6 @@ package main
 import (
 	"html"
 	"net"
-	"net/url"
 	"regexp"
 	"strings"
 )
@@ -39,10 +38,8 @@ func normalizeInput(input string) string {
 		prev := s
 		s = reDoubleEncode.ReplaceAllString(s, "%$1")
 
-		// URL-decode
-		if decoded, err := url.QueryUnescape(strings.ReplaceAll(s, "+", " ")); err == nil {
-			s = decoded
-		}
+		// URL-decode (tolerant: malformed escapes do not abort the whole string)
+		s = percentDecodeTolerant(s)
 
 		// Stop when decoding produces no further change
 		if s == prev {
@@ -106,4 +103,73 @@ func isTextContent(contentType string) bool {
 		}
 	}
 	return false
+}
+
+// percentDecodeTolerant decodes %XX escapes, leaving malformed escapes (e.g.
+// "%ZZ" or a trailing "%") as literal text. Unlike url.QueryUnescape — which is
+// all-or-nothing and returns the input UNDECODED on the first bad escape — a
+// single invalid token here does not abort decoding of the rest of the string.
+// That all-or-nothing behavior was a full WAF bypass: appending one bad token
+// (e.g. "%3Cscript%3E%ZZ") kept the real payload encoded and unscanned. "+" is
+// decoded to a space to match query-string semantics.
+func percentDecodeTolerant(s string) string {
+	if !strings.ContainsAny(s, "%+") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; c {
+		case '%':
+			if i+2 < len(s) {
+				if hi, ok := fromHex(s[i+1]); ok {
+					if lo, ok2 := fromHex(s[i+2]); ok2 {
+						b.WriteByte(hi<<4 | lo)
+						i += 2
+						continue
+					}
+				}
+			}
+			b.WriteByte('%') // malformed escape — keep literal, keep scanning
+		case '+':
+			b.WriteByte(' ')
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
+
+func fromHex(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}
+
+// nonInspectableMedia are opaque binary media types that regex rules cannot
+// meaningfully match. Most are already offloaded by the ICAP Transfer-Ignore
+// list, so they rarely reach the WAF with a body.
+var nonInspectableMedia = []string{
+	"image/", "video/", "audio/", "font/", "application/font",
+}
+
+// shouldInspectBody decides whether a request body is worth scanning. Crucially
+// it must NOT let the attacker-declared Content-Type be used to SKIP inspection:
+// the previous text-only gate let any body through as long as it was labelled
+// e.g. application/octet-stream. We therefore inspect by default and only skip a
+// small set of genuinely opaque media types.
+func shouldInspectBody(contentType string) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	for _, skip := range nonInspectableMedia {
+		if strings.HasPrefix(ct, skip) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
First wave of the ruthless audit (security-first). 11 atomic commits, all 9 required CI checks green (incl. E2E compose-up). Supersedes #87 (closed: history was rewritten, GitHub pinned it to orphaned SHAs).

**History purge done:** `config/ssl_*.pem` (the SSL-bump CA) and a stray 64MB `data/secure_proxy.db` were purged from all of `main`'s history via filter-repo + force-push (branch protection temporarily lifted and restored identically). The CA keypair must still be treated as permanently compromised (3 forks + GitHub caches retain copies); `proxy/startup.sh` rejects/regenerates it on boot.

## 🔒 Security
- SECRET_KEY strength validation at startup (fail-closed).
- WAF: tolerant percent-decoder (closes `%ZZ` decode-abort bypass); method-scoped safe-cache (closes GET-poisons-POST); body inspection not skippable via `Content-Type`; ICAP fails **closed** on panic (`WAF_FAIL_OPEN=1` to opt out).
- docker.sock client constrained to a container/command/signal allowlist.
- SSRF: dial-time IP validation (closes DNS-rebinding TOCTOU) + redirect re-validation + CGNAT; settings mass-assignment writable-key allowlist + encrypt-on-restore.
- CI: govulncheck (informational) + Trivy (gates fixable HIGH/CRITICAL deps) + image SBOM/provenance; Dependabot extended to github-actions and /docs.

## ⚡ Performance
- DB: populate `unix_timestamp`/`elapsed_ms` (index was indexing NULLs) + backfill; batch the log tailer in a transaction; persist the tail offset (no more re-ingest on restart).
- UI: drop recharts (~110KB gzip) from the entry modulepreload.

## 🎯 Usability / quality
- Setup Wizard now applies its config via reload-config ("Setup complete" was misleading).
- Docs: `.env.example` no longer ships a password the backend rejects; `DEPLOYMENT.md` realigned to the Go backend.
- Removed legacy Python `backend/` cruft; pre-commit realigned to Go.

## Follow-ups (documented, not here)
Analytics range-scan on `unix_timestamp`; cosign signing + SHA-pinning docker/* actions; CodeQL triage; `SortTh`-in-render bug in `Clients.tsx`; surface `ClientSetup`. Complete README rewrite is being done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)