### PR TITLE
fix: bogon-strip IP blacklist, port-tolerant WS origin, reliable Trivy install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           # Download the pinned release binary directly — the upstream install.sh
           # is flaky in CI (exits 1 after resolving the version).
-          VER=0.58.1
+          VER=0.69.3
           curl -sfL "https://github.com/aquasecurity/trivy/releases/download/v${VER}/trivy_${VER}_Linux-64bit.tar.gz" -o /tmp/trivy.tgz
           tar -xzf /tmp/trivy.tgz -C /tmp trivy
           sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Trivy
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/v0.58.1/contrib/install.sh \
-            | sudo sh -s -- -b /usr/local/bin v0.58.1
+          # Download the pinned release binary directly — the upstream install.sh
+          # is flaky in CI (exits 1 after resolving the version).
+          VER=0.58.1
+          curl -sfL "https://github.com/aquasecurity/trivy/releases/download/v${VER}/trivy_${VER}_Linux-64bit.tar.gz" -o /tmp/trivy.tgz
+          tar -xzf /tmp/trivy.tgz -C /tmp trivy
+          sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy
+          trivy --version
       - name: Scan dependencies for fixable high/critical CVEs
         run: |
           trivy fs --scanners vuln \

--- a/backend-go/cmd/server/main.go
+++ b/backend-go/cmd/server/main.go
@@ -4,8 +4,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/pprof"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -153,11 +155,18 @@ func run() error {
 			if _, ok := wsAllowed[origin]; ok {
 				return true
 			}
-			// Allow WebSocket from the same host the request arrived on
-			// (covers IP-based access where CORS_ALLOWED_ORIGINS lists only localhost).
+			// Allow WebSocket from the same host the page was served from. Compare
+			// HOSTNAMES (port-tolerant): the browser Origin carries the public port
+			// (e.g. https://192.168.122.107:8443) but nginx forwards Host as $host
+			// without the port, so an exact "scheme+host" match would wrongly fail
+			// for IP-based access where CORS_ALLOWED_ORIGINS lists only localhost.
 			if r.Host != "" {
-				for _, scheme := range []string{"https://", "http://"} {
-					if origin == scheme+r.Host {
+				if ou, err := url.Parse(origin); err == nil && ou.Hostname() != "" {
+					rh := r.Host
+					if h, _, e := net.SplitHostPort(rh); e == nil {
+						rh = h
+					}
+					if ou.Hostname() == rh {
 						return true
 					}
 				}

--- a/backend-go/internal/handlers/blacklists.go
+++ b/backend-go/internal/handlers/blacklists.go
@@ -190,6 +190,10 @@ func (h *BlacklistHandlers) AddIP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid IP address or CIDR format")
 		return
 	}
+	if isLANBogonCIDR(ip) {
+		writeError(w, http.StatusBadRequest, "private/RFC1918/bogon ranges cannot be blacklisted — the IP blacklist is a source ACL, so this would block your own LAN clients")
+		return
+	}
 	_, err := h.db.Exec("INSERT INTO ip_blacklist(ip, description) VALUES(?,?)", ip, item.Description)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE") {
@@ -371,7 +375,7 @@ func (h *BlacklistHandlers) Import(w http.ResponseWriter, r *http.Request) {
 
 	var toInsert [][2]string
 	importDesc := "Imported on " + time.Now().Format("2006-01-02")
-	added, skipped := 0, 0
+	added, skipped, bogonSkipped := 0, 0, 0
 	for _, line := range strings.Split(content, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
@@ -384,6 +388,13 @@ func (h *BlacklistHandlers) Import(w http.ResponseWriter, r *http.Request) {
 		entry := parts[len(parts)-1]
 		if blType == "ip" {
 			if !isValidCIDR(entry) {
+				skipped++
+				continue
+			}
+			// Firehol/bogon feeds include RFC1918 + loopback ranges; importing
+			// them into the source ip_blacklist would lock out the LAN clients.
+			if isLANBogonCIDR(entry) {
+				bogonSkipped++
 				skipped++
 				continue
 			}
@@ -451,10 +462,14 @@ func (h *BlacklistHandlers) Import(w http.ResponseWriter, r *http.Request) {
 	if added > 0 {
 		go propagate(h.db, h.cfg, blType)
 	}
+	msg := fmt.Sprintf("Successfully imported %d entries (%d skipped/invalid)", added, skipped)
+	if bogonSkipped > 0 {
+		msg += fmt.Sprintf(" — %d private/bogon ranges were dropped (a source IP blacklist must not include LAN ranges)", bogonSkipped)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status":  "success",
-		"message": fmt.Sprintf("Successfully imported %d entries (%d skipped/invalid)", added, skipped),
-		"data":    map[string]any{"added": added, "skipped": skipped},
+		"message": msg,
+		"data":    map[string]any{"added": added, "skipped": skipped, "bogon_skipped": bogonSkipped},
 	})
 }
 

--- a/backend-go/internal/handlers/blacklists_test.go
+++ b/backend-go/internal/handlers/blacklists_test.go
@@ -23,7 +23,7 @@ func TestBlacklistHandlers_List(t *testing.T) {
 	_, _ = db.Exec("INSERT INTO ip_blacklist (ip, description) VALUES (?,?)", "2.2.2.2", "other ip")
 
 	handler := listHandler(db, "ip_blacklist", "ip")
-	
+
 	// Basic list
 	r := httptest.NewRequest("GET", "/api/ip-blacklist", nil)
 	w := httptest.NewRecorder()
@@ -49,7 +49,7 @@ func TestBlacklistHandlers_AddIP(t *testing.T) {
 	defer cleanup()
 	h := NewBlacklistHandlers(db, cfg)
 
-	item := models.IPListItem{IP: "10.10.10.10", Description: "New IP"}
+	item := models.IPListItem{IP: "203.0.113.10", Description: "New IP"}
 	body, _ := json.Marshal(item)
 	r := httptest.NewRequest("POST", "/api/ip-blacklist", bytes.NewBuffer(body))
 	w := httptest.NewRecorder()
@@ -59,8 +59,16 @@ func TestBlacklistHandlers_AddIP(t *testing.T) {
 		t.Errorf("Expected 200, got %d", w.Code)
 	}
 
+	// Private/RFC1918 ranges must be rejected from the source IP blacklist.
+	rejW := httptest.NewRecorder()
+	rejBody, _ := json.Marshal(models.IPListItem{IP: "192.168.0.0/16"})
+	h.AddIP(rejW, httptest.NewRequest("POST", "/api/ip-blacklist", bytes.NewBuffer(rejBody)))
+	if rejW.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for a private range, got %d", rejW.Code)
+	}
+
 	var count int
-	_ = db.QueryRow("SELECT COUNT(*) FROM ip_blacklist WHERE ip='10.10.10.10'").Scan(&count)
+	_ = db.QueryRow("SELECT COUNT(*) FROM ip_blacklist WHERE ip='203.0.113.10'").Scan(&count)
 	if count != 1 {
 		t.Error("IP not found in database")
 	}
@@ -76,14 +84,14 @@ func TestBlacklistHandlers_Delete(t *testing.T) {
 	_ = db.QueryRow("SELECT id FROM ip_blacklist WHERE ip='5.5.5.5'").Scan(&id)
 
 	handler := deleteByIDHandler(db, "ip_blacklist", cfg)
-	
+
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", fmt.Sprintf("%d", id))
 	r := httptest.NewRequest("DELETE", "/api/ip-blacklist/"+fmt.Sprintf("%d", id), nil)
 	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected 200, got %d", w.Code)
 	}
@@ -108,13 +116,13 @@ func TestBlacklistHandlers_BulkDelete(t *testing.T) {
 	_ = db.QueryRow("SELECT id FROM ip_blacklist WHERE ip='7.7.7.7'").Scan(&id2)
 
 	handler := bulkDeleteHandler(db, "ip_blacklist", cfg)
-	
+
 	req := models.BulkDeleteRequest{IDs: []int64{id1, id2}}
 	body, _ := json.Marshal(req)
 	r := httptest.NewRequest("POST", "/api/ip-blacklist/bulk-delete", bytes.NewBuffer(body))
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected 200, got %d", w.Code)
 	}
@@ -126,12 +134,12 @@ func TestBlacklistHandlers_ClearAll(t *testing.T) {
 	defer cleanup()
 
 	_, _ = db.Exec("INSERT INTO ip_blacklist (ip) VALUES (?)", "8.8.8.8")
-	
+
 	handler := clearAllHandler(db, "ip_blacklist", cfg, "ip")
 	r := httptest.NewRequest("DELETE", "/api/ip-blacklist/clear-all", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected 200, got %d", w.Code)
 	}
@@ -149,23 +157,29 @@ func TestBlacklistHandlers_ImportContent(t *testing.T) {
 	defer cleanup()
 	h := NewBlacklistHandlers(db, cfg)
 
+	// 3 routable IPs + one private range that must be dropped (source ACL).
 	req := models.ImportBlacklistRequest{
 		Type:    "ip",
-		Content: "10.0.0.1\n# Comment\n10.0.0.2\n1.1.1.1",
+		Content: "203.0.113.1\n# Comment\n203.0.113.2\n1.1.1.1\n192.168.5.5",
 	}
 	body, _ := json.Marshal(req)
 	r := httptest.NewRequest("POST", "/api/blacklists/import", bytes.NewBuffer(body))
 	w := httptest.NewRecorder()
 	h.Import(w, r)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected 200, got %d", w.Code)
 	}
 
 	var count int
 	_ = db.QueryRow("SELECT COUNT(*) FROM ip_blacklist").Scan(&count)
-	if count < 3 {
-		t.Errorf("Expected at least 3 entries imported, got %d", count)
+	if count != 3 {
+		t.Errorf("Expected 3 routable entries imported, got %d", count)
+	}
+	var priv int
+	_ = db.QueryRow("SELECT COUNT(*) FROM ip_blacklist WHERE ip='192.168.5.5'").Scan(&priv)
+	if priv != 0 {
+		t.Error("private range 192.168.5.5 must not be imported into the source IP blacklist")
 	}
 	time.Sleep(100 * time.Millisecond)
 }

--- a/backend-go/internal/handlers/helpers.go
+++ b/backend-go/internal/handlers/helpers.go
@@ -81,6 +81,22 @@ func isBlockedIP(ip net.IP) bool {
 	return false
 }
 
+// isLANBogonCIDR reports whether an IP/CIDR is a private (RFC1918), loopback,
+// link-local, CGNAT or otherwise non-routable range. Such entries must NOT enter
+// the SOURCE ip_blacklist: it is matched as `acl ip_blacklist src` and denied
+// before `allow localnet`/`allow localhost`, so adding e.g. 192.168.0.0/16 (as
+// Firehol/bogon feeds do) would block the proxy's own LAN clients.
+func isLANBogonCIDR(s string) bool {
+	s = strings.TrimSpace(s)
+	if _, ipnet, err := net.ParseCIDR(s); err == nil {
+		return isBlockedIP(ipnet.IP)
+	}
+	if ip := net.ParseIP(s); ip != nil {
+		return isBlockedIP(ip)
+	}
+	return false
+}
+
 // isSSRFTarget resolves the hostname in rawURL and returns true if ANY resolved
 // IP is non-routable. This is the early pre-flight check; the actual fetch is
 // additionally guarded at dial time by ssrfSafeClient (see below), so a DNS

--- a/backend-go/internal/handlers/helpers_test.go
+++ b/backend-go/internal/handlers/helpers_test.go
@@ -25,6 +25,25 @@ func TestIsBlockedIP(t *testing.T) {
 	}
 }
 
+func TestIsLANBogonCIDR(t *testing.T) {
+	bogon := []string{
+		"0.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8",
+		"169.254.0.0/16", "172.16.0.0/12", "192.168.0.0/16",
+		"192.168.122.0/24", "10.1.2.3", "127.0.0.1", "::1", "fe80::/10", "fc00::/7",
+	}
+	for _, c := range bogon {
+		if !isLANBogonCIDR(c) {
+			t.Errorf("isLANBogonCIDR(%q) = false, want true", c)
+		}
+	}
+	routable := []string{"8.8.8.8/32", "1.1.1.1", "93.184.216.0/24", "203.0.113.5", "2606:4700::/32"}
+	for _, c := range routable {
+		if isLANBogonCIDR(c) {
+			t.Errorf("isLANBogonCIDR(%q) = true, want false", c)
+		}
+	}
+}
+
 func TestIsWritableSettingKey(t *testing.T) {
 	bad := []string{"default_password_changed", "has space", "semi;colon", "", "../etc"}
 	for _, k := range bad {


### PR DESCRIPTION
Three fixes surfaced while deploying to the LAN proxy box (CT130).

## 1. RFC1918/bogon in IP blacklist locked out LAN clients (blocker)
The `ip_blacklist` is a Squid **source** ACL (`acl ip_blacklist src`), denied
before `allow localnet`/`allow localhost`. Firehol/bogon feeds include RFC1918 +
loopback ranges (`0.0.0.0/8`, `10/8`, `127/8`, `172.16/12`, `192.168/16`,
`100.64/10`), so importing them made the proxy deny its own LAN clients —
every request became `TCP_DENIED/403`. `AddIP` now rejects such ranges (400)
and `Import` drops them (reported as `bogon_skipped`), via a shared
`isLANBogonCIDR` built on the existing `isBlockedIP`.

## 2. Logs WebSocket failed for IP-based access
`/api/ws/logs` failed with "closed before established" when accessed via
`https://<ip>:8443`: nginx forwards `Host: $host` (no port) but the browser
`Origin` carries `:8443`, so the exact same-host `CheckOrigin` match failed.
The check now compares hostnames port-tolerantly.

## 3. Trivy CI install fixed
The upstream install.sh exited 1 in CI; install the pinned release binary
directly.

Tests added for `isLANBogonCIDR`; `AddIP`/`Import` tests updated to the new
(correct) behaviour. All required checks expected green.

Note: a follow-up should also reorder the Squid config so `allow localnet` /
`allow localhost` precede `deny ip_blacklist`, as defence-in-depth against any
future bogon-containing source list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)