### PR TITLE
release: v3.6.0

### DIFF
--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.5.0"
+const AppVersion = "3.6.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.4.4",
+  "version": "3.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump 3.5.0 → 3.6.0 for the security hardening wave (#88) + LAN-proxy
fixes (#92), now both on main and deployed.

Minor (not patch): the wave introduces fail-closed WAF behaviour and startup
validation (SECRET_KEY strength) that can change upgrade behaviour.

Merging this tags v3.6.0, which triggers the multi-arch image build/push to
ghcr with SBOM + provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)