### PR TITLE
release: v3.6.1

### DIFF
--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.6.0"
+const AppVersion = "3.6.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.6.0",
+  "version": "3.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump for polish wave 1 (#94). Merging tags v3.6.1 and triggers the multi-arch image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)