### PR TITLE
fix: docker restart timeout + log-tailer offset path (prod patch v3.6.2)

### DIFF
--- a/backend-go/cmd/server/main.go
+++ b/backend-go/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -96,7 +97,7 @@ func run() error {
 	// ── background workers ───────────────────────────────────────────────────
 	workerCtx, workerCancel := context.WithCancel(context.Background())
 	defer workerCancel()
-	workers.StartLogTailer(workerCtx, db, cfg.LogPath, hub)
+	workers.StartLogTailer(workerCtx, db, cfg.LogPath, filepath.Dir(cfg.DatabasePath), hub)
 	workers.StartLogRetention(workerCtx, db)
 	workers.StartBlacklistRefresh(workerCtx, db, cfg.ConfigDir)
 	workers.StartUpdateChecker(workerCtx, "")

--- a/backend-go/internal/docker/client.go
+++ b/backend-go/internal/docker/client.go
@@ -78,7 +78,10 @@ func New() *Client {
 			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, "unix", dockerSock)
 		},
 	}
-	return &Client{hc: &http.Client{Transport: transport, Timeout: 10 * time.Second}}
+	// No global client Timeout: each method sets its own per-request context
+	// deadline, because a container restart waits for the graceful stop and needs
+	// far longer than the quick kill/exec calls.
+	return &Client{hc: &http.Client{Transport: transport}}
 }
 
 // KillContainer sends signal to a container via the Docker Engine API.
@@ -92,7 +95,9 @@ func (c *Client) KillContainer(name, signal string) error {
 	}
 	u := fmt.Sprintf("http://localhost/v1.41/containers/%s/kill?signal=%s",
 		url.PathEscape(name), url.QueryEscape(signal))
-	req, err := http.NewRequest(http.MethodPost, u, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
@@ -113,8 +118,14 @@ func (c *Client) RestartContainer(name string) error {
 	if err := checkContainerAllowed(name); err != nil {
 		return err
 	}
-	u := fmt.Sprintf("http://localhost/v1.41/containers/%s/restart", url.PathEscape(name))
-	req, err := http.NewRequest(http.MethodPost, u, nil)
+	// ?t=5 caps the graceful-stop wait at 5s (a Squid with a large ACL set can be
+	// slow to drain); the 60s context covers stop+start. The previous shared 10s
+	// client timeout fired before the restart returned ("context deadline
+	// exceeded"), so ReloadConfig wrongly reported "proxy restart failed".
+	u := fmt.Sprintf("http://localhost/v1.41/containers/%s/restart?t=5", url.PathEscape(name))
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
@@ -139,6 +150,9 @@ func (c *Client) ExecContainer(name string, cmd []string) (string, error) {
 		return "", fmt.Errorf("docker: exec command %v is not in the allowlist", cmd)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
 	// Step 1: Create exec instance
 	createBody, _ := json.Marshal(map[string]any{
 		"AttachStdout": true,
@@ -146,7 +160,7 @@ func (c *Client) ExecContainer(name string, cmd []string) (string, error) {
 		"Cmd":          cmd,
 	})
 	createURL := fmt.Sprintf("http://localhost/v1.41/containers/%s/exec", url.PathEscape(name))
-	createReq, err := http.NewRequest(http.MethodPost, createURL, bytes.NewReader(createBody))
+	createReq, err := http.NewRequestWithContext(ctx, http.MethodPost, createURL, bytes.NewReader(createBody))
 	if err != nil {
 		return "", fmt.Errorf("build exec create request: %w", err)
 	}
@@ -169,7 +183,7 @@ func (c *Client) ExecContainer(name string, cmd []string) (string, error) {
 	// Step 2: Start exec and capture output
 	startBody, _ := json.Marshal(map[string]any{"Detach": false, "Tty": false})
 	startURL := fmt.Sprintf("http://localhost/v1.41/exec/%s/start", execResult.ID)
-	startReq, err := http.NewRequest(http.MethodPost, startURL, bytes.NewReader(startBody))
+	startReq, err := http.NewRequestWithContext(ctx, http.MethodPost, startURL, bytes.NewReader(startBody))
 	if err != nil {
 		return "", fmt.Errorf("build exec start request: %w", err)
 	}

--- a/backend-go/internal/docker/docker_test.go
+++ b/backend-go/internal/docker/docker_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 )
 
 type mockRoundTripper struct {
@@ -118,7 +117,7 @@ func TestNew(t *testing.T) {
 	if c == nil || c.hc == nil {
 		t.Fatal("New() returned nil client or http client")
 	}
-	if c.hc.Timeout != 10*time.Second {
-		t.Errorf("Expected 10s timeout, got %v", c.hc.Timeout)
+	if c.hc.Timeout != 0 {
+		t.Errorf("Expected no global client timeout (per-request contexts), got %v", c.hc.Timeout)
 	}
 }

--- a/backend-go/internal/workers/log_tailer.go
+++ b/backend-go/internal/workers/log_tailer.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -18,12 +19,15 @@ import (
 )
 
 // StartLogTailer tails the Squid access log and inserts rows into proxy_logs.
-// It also broadcasts a JSON representation to the WebSocket hub.
-func StartLogTailer(ctx context.Context, db *sql.DB, logPath string, hub *websocket.Hub) {
+// It also broadcasts a JSON representation to the WebSocket hub. stateDir is a
+// backend-writable directory (e.g. /data) where the tail offset is persisted —
+// the log directory itself is typically not writable by the backend's user.
+func StartLogTailer(ctx context.Context, db *sql.DB, logPath, stateDir string, hub *websocket.Hub) {
+	posPath := filepath.Join(stateDir, filepath.Base(logPath)+".pos")
 	go func() {
 		// Restore the persisted byte offset so a backend restart does not re-read
 		// the whole file from the start and re-insert every still-present line.
-		offset := readOffset(logPath)
+		offset := readOffset(posPath)
 		ticker := time.NewTicker(500 * time.Millisecond)
 		defer ticker.Stop()
 		for {
@@ -92,17 +96,14 @@ func StartLogTailer(ctx context.Context, db *sql.DB, logPath string, hub *websoc
 			} else {
 				offset = fi.Size()
 			}
-			writeOffset(logPath, offset)
+			writeOffset(posPath, offset)
 		}
 	}()
 	log.Info().Str("path", logPath).Msg("log tailer started")
 }
 
-// offsetPath returns the sidecar file that persists the tail position.
-func offsetPath(logPath string) string { return logPath + ".pos" }
-
-func readOffset(logPath string) int64 {
-	data, err := os.ReadFile(offsetPath(logPath)) // #nosec G304 — derived from configured log path
+func readOffset(posPath string) int64 {
+	data, err := os.ReadFile(posPath) // #nosec G304 — derived from configured data dir
 	if err != nil {
 		return 0
 	}
@@ -113,13 +114,13 @@ func readOffset(logPath string) int64 {
 	return n
 }
 
-func writeOffset(logPath string, offset int64) {
-	tmp := offsetPath(logPath) + ".tmp"
+func writeOffset(posPath string, offset int64) {
+	tmp := posPath + ".tmp"
 	if err := os.WriteFile(tmp, []byte(strconv.FormatInt(offset, 10)), 0o600); err != nil {
 		log.Warn().Err(err).Msg("log tailer: cannot persist offset (will re-read on restart)")
 		return
 	}
-	if err := os.Rename(tmp, offsetPath(logPath)); err != nil {
+	if err := os.Rename(tmp, posPath); err != nil {
 		log.Warn().Err(err).Msg("log tailer: cannot move offset file into place")
 	}
 }

--- a/backend-go/internal/workers/workers_test.go
+++ b/backend-go/internal/workers/workers_test.go
@@ -282,7 +282,7 @@ func TestStartWorkers_Basic(t *testing.T) {
 
 	logFile := filepath.Join(tmpDir, "access.log")
 	_ = os.WriteFile(logFile, []byte("test"), 0644)
-	StartLogTailer(ctx, db, logFile, hub)
+	StartLogTailer(ctx, db, logFile, tmpDir, hub)
 
 	time.Sleep(100 * time.Millisecond)
 }


### PR DESCRIPTION
Two bugs found while verifying the v3.6.1 deploy on prod:

1. **docker restart timeout** — the client's shared 10s timeout fired before `restart` returned (Squid graceful stop is slow), so ReloadConfig reported "proxy restart failed". Now uses per-request context deadlines (restart 60s) + `?t=5`.
2. **log-tailer offset path** — the .pos was written to /logs (not writable by the backend), so the offset never persisted and logs were re-ingested on restart. Now written to the data dir (/data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)