### PR TITLE
release: v3.6.2

### DIFF
--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.6.1"
+const AppVersion = "3.6.2"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.6.1",
+  "version": "3.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch bump for #96 (prod fixes: docker restart timeout, log offset path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)