### PR TITLE
release: v3.6.3

### DIFF
--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.6.2"
+const AppVersion = "3.6.3"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.6.2",
+  "version": "3.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump 3.6.2 → 3.6.3 for the Wave 1b release (#98).

Ships:
- Worker SSRF + RFC1918/bogon parity for the auto-refresh blacklist worker
- Bounded Squid logs (`logfile_rotate` + daily rotate) and branded error pages
- Domain blocks that apply on reload via dnsmasq `addn-hosts` (SIGHUP re-read)

Bumps `backend-go/internal/config/version.go` and `ui/package.json`. Tag + GitHub
release created on the merge commit after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)