### PR TITLE
fix(dns): auto-reload dnsmasq after blacklist refresh + :ro-safe entrypoint

### DIFF
--- a/backend-go/cmd/server/main.go
+++ b/backend-go/cmd/server/main.go
@@ -99,7 +99,7 @@ func run() error {
 	defer workerCancel()
 	workers.StartLogTailer(workerCtx, db, cfg.LogPath, filepath.Dir(cfg.DatabasePath), hub)
 	workers.StartLogRetention(workerCtx, db)
-	workers.StartBlacklistRefresh(workerCtx, db, cfg.ConfigDir)
+	workers.StartBlacklistRefresh(workerCtx, db, cfg.ConfigDir, dockerClient)
 	workers.StartUpdateChecker(workerCtx, "")
 	workers.CheckSquidCVEs()
 

--- a/backend-go/internal/workers/blacklist_refresh.go
+++ b/backend-go/internal/workers/blacklist_refresh.go
@@ -27,8 +27,22 @@ var defaultDomainLists = []string{
 	"https://urlhaus.abuse.ch/downloads/text/",
 }
 
-// StartBlacklistRefresh runs an auto-refresh loop based on DB settings.
-func StartBlacklistRefresh(ctx context.Context, db *sql.DB, configDir string) {
+// dnsSignaler is the subset of docker.DockerClient the refresh worker needs to
+// tell dnsmasq to re-read its exported blocklist. Kept as a local interface so
+// the worker stays testable and nil-safe (a nil signaler simply skips the
+// reload, which is what the unit tests pass).
+type dnsSignaler interface {
+	KillContainer(name, signal string) error
+}
+
+// dnsContainer is the compose-default name of the DNS service, matching the
+// docker client's control allowlist and the ReloadDNS handler.
+const dnsContainer = "secure-proxy-manager-dns-1"
+
+// StartBlacklistRefresh runs an auto-refresh loop based on DB settings. After
+// each export it signals dnsmasq to reload (Squid's blacklists are picked up
+// separately by the proxy-side watchdog; only the DNS sinkhole needs the nudge).
+func StartBlacklistRefresh(ctx context.Context, db *sql.DB, configDir string, dns dnsSignaler) {
 	go func() {
 		for {
 			// Re-read settings on each cycle so changes take effect.
@@ -50,10 +64,28 @@ func StartBlacklistRefresh(ctx context.Context, db *sql.DB, configDir string) {
 			}
 			log.Info().Msg("auto-refresh blacklists starting")
 			refreshAll(db)
-			database.ExportBlacklistsToFiles(db, configDir) //nolint:errcheck
+			if err := database.ExportBlacklistsToFiles(db, configDir); err != nil {
+				log.Warn().Err(err).Msg("blacklist export after auto-refresh failed")
+				continue
+			}
+			signalDNSReload(dns)
 		}
 	}()
 	log.Info().Msg("blacklist auto-refresh worker started")
+}
+
+// signalDNSReload tells dnsmasq to re-read its addn-hosts blocklist via SIGHUP.
+// No-op when dns is nil (tests). Failures are non-fatal: the export already
+// landed on disk and dnsmasq will pick it up on its next reload regardless.
+func signalDNSReload(dns dnsSignaler) {
+	if dns == nil {
+		return
+	}
+	if err := dns.KillContainer(dnsContainer, "HUP"); err != nil {
+		log.Warn().Err(err).Msg("dnsmasq SIGHUP after auto-refresh failed (non-fatal)")
+		return
+	}
+	log.Info().Msg("signaled dnsmasq to reload blocklist after auto-refresh")
 }
 
 func readRefreshSettings(db *sql.DB) (bool, int) {

--- a/backend-go/internal/workers/workers_test.go
+++ b/backend-go/internal/workers/workers_test.go
@@ -278,7 +278,7 @@ func TestStartWorkers_Basic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	StartLogRetention(ctx, db)
-	StartBlacklistRefresh(ctx, db, tmpDir)
+	StartBlacklistRefresh(ctx, db, tmpDir, nil)
 	StartUpdateChecker(ctx, "v1.0.0")
 
 	logFile := filepath.Join(tmpDir, "access.log")
@@ -287,3 +287,36 @@ func TestStartWorkers_Basic(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 }
+
+// fakeDNSSignaler records KillContainer calls for assertion.
+type fakeDNSSignaler struct {
+	name, signal string
+	calls        int
+	err          error
+}
+
+func (f *fakeDNSSignaler) KillContainer(name, signal string) error {
+	f.calls++
+	f.name, f.signal = name, signal
+	return f.err
+}
+
+func TestSignalDNSReload(t *testing.T) {
+	// nil signaler must be a silent no-op (the unit-test/dev path).
+	signalDNSReload(nil)
+
+	// A real signaler gets a SIGHUP to the DNS container.
+	f := &fakeDNSSignaler{}
+	signalDNSReload(f)
+	if f.calls != 1 {
+		t.Fatalf("expected 1 KillContainer call, got %d", f.calls)
+	}
+	if f.name != dnsContainer || f.signal != "HUP" {
+		t.Fatalf("expected KillContainer(%q, HUP), got (%q, %q)", dnsContainer, f.name, f.signal)
+	}
+
+	// A signaler error must not panic (failure is non-fatal).
+	signalDNSReload(&fakeDNSSignaler{err: errTest})
+}
+
+var errTest = fmt.Errorf("boom")

--- a/dns/entrypoint.sh
+++ b/dns/entrypoint.sh
@@ -70,11 +70,15 @@ fi
 
 echo "Upstream DNS: ${DNS1}, ${DNS2}, ${DNS3}"
 
-# Ensure the addn-hosts blocklist exists so dnsmasq doesn't warn before the
-# backend's first export, then count entries for logging.
-mkdir -p /config/dnsmasq.d
-touch /config/dnsmasq.d/blocklist.hosts
-BLOCK_COUNT=$(grep -c "^0.0.0.0 " /config/dnsmasq.d/blocklist.hosts 2>/dev/null || echo 0)
-echo "Blocklist: ${BLOCK_COUNT} entries"
+# Best-effort: create an empty addn-hosts blocklist so dnsmasq doesn't warn
+# before the backend's first export. Silently skipped when /config is mounted
+# read-only (production) — there the backend (read-write mount) owns the file;
+# dnsmasq tolerates it being absent at boot and reads it on the next reload.
+touch /config/dnsmasq.d/blocklist.hosts 2>/dev/null || true
+# busybox `grep -c` prints "0" AND exits non-zero on an empty/non-matching file,
+# so a `|| echo 0` would double-emit ("0\n0"). Capture grep's count directly and
+# default an empty result (missing file) to 0 — one clean line in every case.
+BLOCK_COUNT=$(grep -c "^0.0.0.0 " /config/dnsmasq.d/blocklist.hosts 2>/dev/null || true)
+echo "Blocklist: ${BLOCK_COUNT:-0} entries"
 
 exec dnsmasq --no-daemon --log-facility=- --conf-file=/tmp/dnsmasq.conf


### PR DESCRIPTION
Two small follow-ups surfaced while verifying v3.6.3 live on prod.

### 1. Worker now signals dnsmasq after an auto-refresh
The blacklist auto-refresh worker exported the updated blocklist but never told
dnsmasq to re-read it, so **DNS-level domain blocks lagged until a manual
`reload-dns`**. The worker now SIGHUPs the dns container after a successful
export, via a small nil-safe `dnsSignaler` interface (main passes the real
docker client; tests pass `nil`). The container name + `HUP` signal match the
existing `ReloadDNS` handler and the docker control allowlist, so no new control
surface. Export errors are now logged instead of silently dropped.

Squid's IP/domain blacklists are unaffected — the proxy-side watchdog already
reconfigures Squid on file change; only the DNS sinkhole needed the nudge.

### 2. `:ro`-safe dns entrypoint + clean count log
`dns/entrypoint.sh` created the addn-hosts file with an unconditional
`mkdir`/`touch`, which errors on the production **read-only** `/config` mount
(the backend's read-write mount owns the file). Made it best-effort. Also fixed
the entry-count log: busybox `grep -c` prints `0` **and** exits non-zero on an
empty file, so the old `|| echo 0` double-emitted (`Blocklist: 0\n0 entries`) —
the common fresh-boot state. Now a single clean line. Reproduced + verified the
fix in `alpine:3.21.3`.

### Verification
- `go vet` + `go test ./...` green; new `TestSignalDNSReload` covers the
  container/signal, the nil no-op, and the non-fatal error path.
- Empty/missing/populated `blocklist.hosts` all log one clean line (busybox repro).
- Adversarial multi-agent review (18 agents): no blockers, no correctness or
  security regressions; this finding (#2 log line) was the only real one and is
  fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)