### PR TITLE
release: v3.6.4

### DIFF
--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.6.3"
+const AppVersion = "3.6.4"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.6.3",
+  "version": "3.6.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump 3.6.3 → 3.6.4 for the dnsmasq reload follow-ups (#100).

Ships:
- Auto-refresh worker now SIGHUPs dnsmasq after export (DNS blocks apply without a manual reload-dns)
- `:ro`-safe dns entrypoint + clean blocklist-count log line (busybox `grep -c` fix)

Bumps `backend-go/internal/config/version.go` and `ui/package.json`. Tag + GitHub
release created on the merge commit after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)