### PR TITLE
perf(db): unix_timestamp range scans + bound unbounded analytics windows (Wave 2)

### DIFF
--- a/backend-go/internal/database/db_test.go
+++ b/backend-go/internal/database/db_test.go
@@ -85,6 +85,50 @@ func TestBlockedFlagMigration(t *testing.T) {
 	}
 }
 
+// TestUnixTimestampIndexUsed proves the previously-dead idx_proxy_logs_unix_ts
+// is now consulted: a time-bucketed range query (the TrafficStats/Timeline
+// shape) range-scans the unix_timestamp index instead of doing TEXT-date math.
+func TestUnixTimestampIndexUsed(t *testing.T) {
+	tmpDB := "/tmp/test_unix_idx.db"
+	defer os.Remove(tmpDB)
+
+	db, err := Open(tmpDB)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	if err := Init(db, "admin", "hash"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	for i := 0; i < 1000; i++ {
+		if _, err := db.Exec("INSERT INTO proxy_logs(timestamp, unix_timestamp, destination) VALUES(datetime('now'), ?, 'http://x')", 1700000000+i); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	rs, err := db.Query(`EXPLAIN QUERY PLAN
+		SELECT strftime('%Y-%m-%d %H', datetime((unix_timestamp/300)*300,'unixepoch')) b, COUNT(*)
+		FROM proxy_logs WHERE unix_timestamp >= 1700000500 GROUP BY b`)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rs.Close()
+	used := false
+	for rs.Next() {
+		var id, parent, notused int
+		var detail string
+		if err := rs.Scan(&id, &parent, &notused, &detail); err != nil {
+			t.Fatalf("scan plan: %v", err)
+		}
+		if strings.Contains(detail, "idx_proxy_logs_unix_ts") {
+			used = true
+		}
+	}
+	if !used {
+		t.Errorf("time-window query does not range-scan idx_proxy_logs_unix_ts (index still dead)")
+	}
+}
+
 // TestBlockedColumnAlterMigration exercises the real upgrade path: a legacy
 // proxy_logs table with NO blocked column, on which Init must run the
 // idempotent ALTER ADD COLUMN (filling existing rows with 0) and then backfill.

--- a/backend-go/internal/handlers/analytics.go
+++ b/backend-go/internal/handlers/analytics.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"database/sql"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"regexp"
@@ -128,7 +127,7 @@ func (h *AnalyticsHandlers) TrafficStats(w http.ResponseWriter, r *http.Request)
 		// Bucket into 5-minute slots (rounded down via epoch) so the keys line up
 		// with the 5-minute label grid below. A per-minute %H:%M key never matched
 		// the 5-min-stepped labels, dropping ~all points.
-		interval = `strftime('%Y-%m-%d %H:%M', datetime((strftime('%s', timestamp) / 300) * 300, 'unixepoch'))`
+		interval = `strftime('%Y-%m-%d %H:%M', datetime((unix_timestamp / 300) * 300, 'unixepoch'))`
 		intervalFormat = "2006-01-02 15:04"
 		startDuration = "-1 hours"
 	case "week":
@@ -150,8 +149,8 @@ func (h *AnalyticsHandlers) TrafficStats(w http.ResponseWriter, r *http.Request)
 	rows, err := h.db.Query(`
 		SELECT `+interval+` AS bucket, COUNT(*) AS total,
 		       SUM(blocked) AS blocked
-		FROM proxy_logs WHERE timestamp >= datetime('now', ?) GROUP BY bucket`,
-		startDuration,
+		FROM proxy_logs WHERE unix_timestamp >= ? GROUP BY bucket`,
+		sinceUnix(parseDuration(startDuration)),
 	)
 	bucketMap := map[string]map[string]int{}
 	if err == nil {
@@ -233,14 +232,26 @@ func parseDuration(s string) time.Duration {
 	}
 }
 
+// analyticsWindow is the rolling window for the "top N over recent activity"
+// panels (clients, domains, threat categories, SaaS). One constant keeps the
+// panels from drifting apart.
+const analyticsWindow = 7 * 24 * time.Hour
+
+// sinceUnix returns the Unix-epoch lower bound for a rolling window of length d.
+// Binding this and filtering `unix_timestamp >= ?` lets the query range-scan
+// idx_proxy_logs_unix_ts instead of doing per-row TEXT-date arithmetic with
+// datetime('now', ...), which never used the index.
+func sinceUnix(d time.Duration) int64 { return time.Now().Add(-d).Unix() }
+
 func (h *AnalyticsHandlers) ClientStats(w http.ResponseWriter, r *http.Request) {
+	since := sinceUnix(analyticsWindow)
 	rows, err := h.db.Query(`
 		SELECT source_ip, COUNT(*) AS requests,
 		       SUM(blocked) AS blocked,
 		       MAX(timestamp) AS last_seen
 		FROM proxy_logs
-		WHERE source_ip IS NOT NULL AND source_ip != ''
-		GROUP BY source_ip ORDER BY requests DESC LIMIT 50`)
+		WHERE source_ip IS NOT NULL AND source_ip != '' AND unix_timestamp >= ?
+		GROUP BY source_ip ORDER BY requests DESC LIMIT 50`, since)
 	if err != nil {
 		writeOK(w, map[string]any{"total_clients": 0, "clients": []any{}})
 		return
@@ -261,7 +272,7 @@ func (h *AnalyticsHandlers) ClientStats(w http.ResponseWriter, r *http.Request) 
 		clients = []map[string]any{}
 	}
 	var total int
-	h.db.QueryRow("SELECT COUNT(DISTINCT source_ip) FROM proxy_logs WHERE source_ip IS NOT NULL AND source_ip != ''").Scan(&total) //nolint:errcheck
+	h.db.QueryRow("SELECT COUNT(DISTINCT source_ip) FROM proxy_logs WHERE source_ip IS NOT NULL AND source_ip != '' AND unix_timestamp >= ?", since).Scan(&total) //nolint:errcheck
 	writeOK(w, map[string]any{"total_clients": total, "clients": clients})
 }
 
@@ -328,8 +339,8 @@ func (h *AnalyticsHandlers) DomainStats(w http.ResponseWriter, r *http.Request) 
 	rows, err := h.db.Query(`
 		SELECT destination, COUNT(*) AS requests,
 		       SUM(blocked) AS blocked_requests
-		FROM proxy_logs WHERE destination IS NOT NULL AND destination != ''
-		GROUP BY destination ORDER BY requests DESC LIMIT 50`)
+		FROM proxy_logs WHERE destination IS NOT NULL AND destination != '' AND unix_timestamp >= ?
+		GROUP BY destination ORDER BY requests DESC LIMIT 50`, sinceUnix(analyticsWindow))
 	if err != nil {
 		writeOK(w, []any{})
 		return
@@ -530,7 +541,7 @@ func (h *AnalyticsHandlers) DashboardSummary(w http.ResponseWriter, r *http.Requ
 	result["today_blocked"] = todayBlocked
 
 	var topBlocked []map[string]any
-	rows, _ := h.db.Query(`SELECT destination, COUNT(*) AS cnt FROM proxy_logs WHERE blocked = 1 AND timestamp >= datetime('now','-1 day') GROUP BY destination ORDER BY cnt DESC LIMIT 10`)
+	rows, _ := h.db.Query(`SELECT destination, COUNT(*) AS cnt FROM proxy_logs WHERE blocked = 1 AND unix_timestamp >= ? GROUP BY destination ORDER BY cnt DESC LIMIT 10`, sinceUnix(24*time.Hour))
 	if rows != nil {
 		for rows.Next() {
 			var dest string
@@ -553,7 +564,7 @@ func (h *AnalyticsHandlers) DashboardSummary(w http.ResponseWriter, r *http.Requ
 
 	// Top clients (last 24h)
 	var topClients []map[string]any
-	cRows, _ := h.db.Query(`SELECT source_ip, COUNT(*) AS cnt FROM proxy_logs WHERE timestamp >= datetime('now','-1 day') AND source_ip IS NOT NULL AND source_ip != '' GROUP BY source_ip ORDER BY cnt DESC LIMIT 10`)
+	cRows, _ := h.db.Query(`SELECT source_ip, COUNT(*) AS cnt FROM proxy_logs WHERE unix_timestamp >= ? AND source_ip IS NOT NULL AND source_ip != '' GROUP BY source_ip ORDER BY cnt DESC LIMIT 10`, sinceUnix(24*time.Hour))
 	if cRows != nil {
 		for cRows.Next() {
 			var ip string
@@ -570,7 +581,7 @@ func (h *AnalyticsHandlers) DashboardSummary(w http.ResponseWriter, r *http.Requ
 
 	// Threat categories (last 7 days)
 	var threatCats []map[string]any
-	tRows, _ := h.db.Query(`SELECT CASE WHEN destination LIKE '%.exe%' OR destination LIKE '%.dll%' THEN 'Malware' WHEN status LIKE '%DENIED%' AND destination LIKE '%:%' THEN 'Direct IP' WHEN status LIKE '%403%' THEN 'WAF Block' ELSE 'Policy' END as category, COUNT(*) as cnt FROM proxy_logs WHERE blocked = 1 AND timestamp >= datetime('now','-7 days') GROUP BY category ORDER BY cnt DESC`)
+	tRows, _ := h.db.Query(`SELECT CASE WHEN destination LIKE '%.exe%' OR destination LIKE '%.dll%' THEN 'Malware' WHEN status LIKE '%DENIED%' AND destination LIKE '%:%' THEN 'Direct IP' WHEN status LIKE '%403%' THEN 'WAF Block' ELSE 'Policy' END as category, COUNT(*) as cnt FROM proxy_logs WHERE blocked = 1 AND unix_timestamp >= ? GROUP BY category ORDER BY cnt DESC`, sinceUnix(analyticsWindow))
 	if tRows != nil {
 		for tRows.Next() {
 			var cat string
@@ -657,8 +668,8 @@ func (h *AnalyticsHandlers) ShadowIT(w http.ResponseWriter, r *http.Request) {
 	rows, err := h.db.Query(`
 		SELECT destination, COUNT(*) AS cnt FROM proxy_logs
 		WHERE destination IS NOT NULL AND destination != ''
-		AND timestamp >= datetime('now', '-7 days')
-		GROUP BY destination ORDER BY cnt DESC LIMIT 500`)
+		AND unix_timestamp >= ?
+		GROUP BY destination ORDER BY cnt DESC LIMIT 500`, sinceUnix(analyticsWindow))
 	if err != nil {
 		writeOK(w, []any{})
 		return
@@ -715,8 +726,8 @@ func (h *AnalyticsHandlers) UserAgents(w http.ResponseWriter, r *http.Request) {
 	rows, err := h.db.Query(`
 		SELECT method, COUNT(*) AS cnt FROM proxy_logs
 		WHERE method IS NOT NULL AND method != '' AND method != '-'
-		AND timestamp >= datetime('now', '-7 days')
-		GROUP BY method ORDER BY cnt DESC LIMIT 50`)
+		AND unix_timestamp >= ?
+		GROUP BY method ORDER BY cnt DESC LIMIT 50`, sinceUnix(analyticsWindow))
 	var methods []map[string]any
 	if err == nil {
 		defer rows.Close()
@@ -736,7 +747,7 @@ func (h *AnalyticsHandlers) UserAgents(w http.ResponseWriter, r *http.Request) {
 var extRe = regexp.MustCompile(`\.([a-zA-Z0-9]{1,10})(?:\?|$|#)`)
 
 func (h *AnalyticsHandlers) FileExtensions(w http.ResponseWriter, r *http.Request) {
-	rows, err := h.db.Query(`SELECT destination FROM proxy_logs WHERE destination IS NOT NULL AND destination != '' AND timestamp >= datetime('now', '-7 days') LIMIT 10000`)
+	rows, err := h.db.Query(`SELECT destination FROM proxy_logs WHERE destination IS NOT NULL AND destination != '' AND unix_timestamp >= ? LIMIT 10000`, sinceUnix(analyticsWindow))
 	skipTLDs := map[string]struct{}{"com": {}, "net": {}, "org": {}, "io": {}, "dev": {}, "app": {}, "me": {}, "co": {}}
 	extCounts := map[string]int{}
 	if err == nil {
@@ -765,8 +776,8 @@ func (h *AnalyticsHandlers) TopDomains(w http.ResponseWriter, r *http.Request) {
 	rows, err := h.db.Query(`
 		SELECT destination, COUNT(*) AS cnt FROM proxy_logs
 		WHERE destination IS NOT NULL AND destination != ''
-		AND timestamp >= datetime('now', '-7 days')
-		GROUP BY destination ORDER BY cnt DESC LIMIT 200`)
+		AND unix_timestamp >= ?
+		GROUP BY destination ORDER BY cnt DESC LIMIT 200`, sinceUnix(analyticsWindow))
 	domainCounts := map[string]int{}
 	if err == nil {
 		defer rows.Close()
@@ -898,8 +909,8 @@ func (h *AnalyticsHandlers) TestRule(w http.ResponseWriter, r *http.Request) {
 
 	// Query recent destinations from logs
 	rows, err := h.db.Query(
-		"SELECT destination FROM proxy_logs WHERE timestamp >= datetime('now', ? || ' hours') AND destination IS NOT NULL AND destination != '' LIMIT 10000",
-		fmt.Sprintf("-%d", req.Hours),
+		"SELECT destination FROM proxy_logs WHERE unix_timestamp >= ? AND destination IS NOT NULL AND destination != '' LIMIT 10000",
+		sinceUnix(time.Duration(req.Hours)*time.Hour),
 	)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/backend-go/internal/handlers/analytics_test.go
+++ b/backend-go/internal/handlers/analytics_test.go
@@ -49,9 +49,12 @@ func TestAnalyticsHandlers_TrafficStats_HourBucketing(t *testing.T) {
 	defer cleanup()
 	h := NewAnalyticsHandlers(db, cfg, &mockDockerClient{})
 
-	ts := time.Now().UTC().Add(-12 * time.Minute).Format("2006-01-02 15:04:05")
+	ts := time.Now().UTC().Add(-12 * time.Minute)
+	tsStr := ts.Format("2006-01-02 15:04:05")
 	for i := 0; i < 3; i++ {
-		_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, source_ip, destination, status) VALUES (?, '1.1.1.1', 'http://a.com', '200 OK')", ts)
+		// unix_timestamp is what the time-window range scan now filters/buckets on
+		// (the log tailer always populates it in production).
+		_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, unix_timestamp, source_ip, destination, status) VALUES (?, ?, '1.1.1.1', 'http://a.com', '200 OK')", tsStr, ts.Unix())
 	}
 
 	r := httptest.NewRequest("GET", "/api/traffic/statistics?period=hour", nil)
@@ -80,7 +83,12 @@ func TestAnalyticsHandlers_ClientStats(t *testing.T) {
 	defer cleanup()
 	h := NewAnalyticsHandlers(db, cfg, &mockDockerClient{})
 
-	_, _ = db.Exec("INSERT INTO proxy_logs (source_ip, destination) VALUES ('1.2.3.4', 'http://a.com')")
+	now := time.Now().UTC()
+	// Recent client (in the 7-day window) and an old one (60 days ago, outside it).
+	_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, unix_timestamp, source_ip, destination) VALUES (?, ?, '1.2.3.4', 'http://a.com')",
+		now.Format("2006-01-02 15:04:05"), now.Unix())
+	_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, unix_timestamp, source_ip, destination) VALUES (?, ?, '9.9.9.9', 'http://old.com')",
+		now.AddDate(0, 0, -60).Format("2006-01-02 15:04:05"), now.AddDate(0, 0, -60).Unix())
 
 	r := httptest.NewRequest("GET", "/api/clients/statistics", nil)
 	w := httptest.NewRecorder()
@@ -89,6 +97,29 @@ func TestAnalyticsHandlers_ClientStats(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected 200, got %d", w.Code)
 	}
+	var resp struct {
+		Data struct {
+			Clients []struct {
+				IPAddress string `json:"ip_address"`
+			} `json:"clients"`
+		} `json:"data"`
+	}
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	var hasRecent, hasOld bool
+	for _, c := range resp.Data.Clients {
+		if c.IPAddress == "1.2.3.4" {
+			hasRecent = true
+		}
+		if c.IPAddress == "9.9.9.9" {
+			hasOld = true
+		}
+	}
+	if !hasRecent {
+		t.Error("recent client (in 7-day window) missing from ClientStats")
+	}
+	if hasOld {
+		t.Error("old client (60 days ago) must be excluded by the time-window bound")
+	}
 }
 
 func TestAnalyticsHandlers_DomainStats(t *testing.T) {
@@ -96,7 +127,9 @@ func TestAnalyticsHandlers_DomainStats(t *testing.T) {
 	defer cleanup()
 	h := NewAnalyticsHandlers(db, cfg, &mockDockerClient{})
 
-	_, _ = db.Exec("INSERT INTO proxy_logs (destination, status) VALUES ('example.com', '200 OK')")
+	now := time.Now().UTC()
+	_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, unix_timestamp, destination, status) VALUES (?, ?, 'example.com', '200 OK')",
+		now.Format("2006-01-02 15:04:05"), now.Unix())
 
 	r := httptest.NewRequest("GET", "/api/domains/statistics", nil)
 	w := httptest.NewRecorder()

--- a/backend-go/internal/handlers/analytics_test.go
+++ b/backend-go/internal/handlers/analytics_test.go
@@ -145,7 +145,7 @@ func TestAnalyticsHandlers_DashboardSummary(t *testing.T) {
 	defer cleanup()
 	h := NewAnalyticsHandlers(db, cfg, &mockDockerClient{})
 
-	_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, destination, status) VALUES (datetime('now'), 'evil.com', '403 Forbidden')")
+	_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, unix_timestamp, destination, status, blocked) VALUES (datetime('now'), strftime('%s','now'), 'evil.com', '403 Forbidden', 1)")
 
 	r := httptest.NewRequest("GET", "/api/dashboard/summary", nil)
 	w := httptest.NewRecorder()
@@ -161,7 +161,7 @@ func TestAnalyticsHandlers_ShadowIT(t *testing.T) {
 	defer cleanup()
 	h := NewAnalyticsHandlers(db, cfg, &mockDockerClient{})
 
-	_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, destination) VALUES (datetime('now'), 'dropbox.com')")
+	_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, unix_timestamp, destination) VALUES (datetime('now'), strftime('%s','now'), 'dropbox.com')")
 
 	r := httptest.NewRequest("GET", "/api/analytics/shadow-it", nil)
 	w := httptest.NewRecorder()
@@ -193,7 +193,7 @@ func TestAnalyticsHandlers_TestRule(t *testing.T) {
 	defer cleanup()
 	h := NewAnalyticsHandlers(db, cfg, &mockDockerClient{})
 
-	_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, destination) VALUES (datetime('now'), 'malware-site.com')")
+	_, _ = db.Exec("INSERT INTO proxy_logs (timestamp, unix_timestamp, destination) VALUES (datetime('now'), strftime('%s','now'), 'malware-site.com')")
 
 	req := struct {
 		Regex string `json:"regex"`

--- a/backend-go/internal/handlers/logs.go
+++ b/backend-go/internal/handlers/logs.go
@@ -126,9 +126,9 @@ func (h *LogHandlers) Timeline(w http.ResponseWriter, r *http.Request) {
 		       COUNT(*) as total,
 		       SUM(blocked) as blocked
 		FROM proxy_logs
-		WHERE timestamp >= datetime('now', ?)
+		WHERE unix_timestamp >= ?
 		GROUP BY hour ORDER BY hour ASC`,
-		"-"+strconv.Itoa(hours)+" hours",
+		time.Now().Add(-time.Duration(hours)*time.Hour).Unix(),
 	)
 	if err != nil {
 		writeOK(w, []any{})

--- a/ui/src/pages/Clients.tsx
+++ b/ui/src/pages/Clients.tsx
@@ -88,7 +88,7 @@ export function Clients() {
             Clients
           </h1>
           <p className="text-sm text-muted-foreground mt-0.5">
-            Source IPs seen by the proxy{typeof data?.total_clients === 'number' ? ` — ${data.total_clients} total` : ''}. Select a row for details.
+            Source IPs seen in the last 7 days{typeof data?.total_clients === 'number' ? ` — ${data.total_clients}` : ''}. Select a row for details.
           </p>
         </div>
         <button


### PR DESCRIPTION
**Wave 2 — PR 3 of 6.** Makes the dead `unix_timestamp` index live and bounds the full-table GROUP BY scans.

### Item 1 — range-scan `unix_timestamp` (kill the dead index)
Every analytics/log time-window read filtered `timestamp >= datetime('now', ...)`
(TEXT-date arithmetic) while the populated `unix_timestamp` column + its index had
**zero readers**. Converted the read-path predicates to `unix_timestamp >= ?` with a
Go-computed epoch bound (`sinceUnix` helper): TrafficStats (also drops the per-row
`strftime('%s', timestamp)` in the 5-min bucket), top_blocked, top_clients,
threat_categories, ShadowIT, UserAgents, FileExtensions, TopDomains, TestRule, and
the logs Timeline. The retention `DELETE`s stay on TEXT (not hot; off-by-one risk).

### Item 3 — bound the unbounded GROUP BY scans
`ClientStats` (+ its distinct total) and `DomainStats` grouped the **whole** table on
every dashboard load. Added a shared 7-day window (`analyticsWindow`). DashboardSummary
lifetime totals and logs Stats stay unbounded **on purpose** — all-time KPIs, already
made cheap by #104 (`SUM(blocked)` + partial index).

### Verification
- `go test ./...` green. The TrafficStats hour-bucket fixture now populates
  `unix_timestamp`; a ClientStats window test asserts a recent client is included and
  a 60-day-old one excluded; an **EXPLAIN QUERY PLAN test** proves a time-bucketed
  range query now uses `idx_proxy_logs_unix_ts` (index no longer dead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)