### PR TITLE
fix(api): dashboard WAF /stats fan-out inside the circuit breaker (Wave 2)

### DIFF
--- a/backend-go/internal/handlers/analytics.go
+++ b/backend-go/internal/handlers/analytics.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"regexp"
@@ -27,9 +29,11 @@ var (
 	probeClient = &http.Client{Timeout: 1 * time.Second}
 )
 
-// wafGet performs a GET request to the WAF management API with Basic Auth.
-func wafGet(cfg *config.Config, path string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", cfg.WAFURL+path, nil)
+// wafGet performs a GET request to the WAF management API with Basic Auth. The
+// request is bound to ctx, so a client disconnect (or the 3s client timeout)
+// cancels the upstream call instead of leaking it.
+func wafGet(ctx context.Context, cfg *config.Config, path string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", cfg.WAFURL+path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -38,14 +42,47 @@ func wafGet(cfg *config.Config, path string) (*http.Response, error) {
 }
 
 // wafPost performs a POST request to the WAF management API with Basic Auth.
-func wafPost(cfg *config.Config, path, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest("POST", cfg.WAFURL+path, body)
+func wafPost(ctx context.Context, cfg *config.Config, path, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", cfg.WAFURL+path, body)
 	if err != nil {
 		return nil, err
 	}
 	req.SetBasicAuth(cfg.AdminUsername, cfg.AdminPassword)
 	req.Header.Set("Content-Type", contentType)
 	return wafClient.Do(req)
+}
+
+// wafGetBreaker is wafGet behind the circuit breaker: it returns
+// appMW.ErrCircuitOpen without a network call when the WAF has been failing, and
+// records success/failure so the breaker trips and resets. Every WAF GET
+// fan-out goes through this so none can silently drift out of breaker coverage —
+// the dashboard /stats poll previously did, blocking each dashboard load for the
+// full client timeout whenever the WAF was down.
+func wafGetBreaker(ctx context.Context, cfg *config.Config, path string) (*http.Response, error) {
+	if err := wafBreaker.Allow(); err != nil {
+		return nil, err
+	}
+	resp, err := wafGet(ctx, cfg, path)
+	if err != nil {
+		wafBreaker.RecordFailure()
+		return nil, err
+	}
+	wafBreaker.RecordSuccess()
+	return resp, nil
+}
+
+// wafPostBreaker is wafPost behind the same circuit breaker.
+func wafPostBreaker(ctx context.Context, cfg *config.Config, path, contentType string, body io.Reader) (*http.Response, error) {
+	if err := wafBreaker.Allow(); err != nil {
+		return nil, err
+	}
+	resp, err := wafPost(ctx, cfg, path, contentType, body)
+	if err != nil {
+		wafBreaker.RecordFailure()
+		return nil, err
+	}
+	wafBreaker.RecordSuccess()
+	return resp, nil
 }
 
 // dockerExecer is the subset of docker.DockerClient needed for cache stats.
@@ -482,18 +519,16 @@ func parseSquidInfo(raw string) map[string]any {
 }
 
 func (h *AnalyticsHandlers) WAFStats(w http.ResponseWriter, r *http.Request) {
-	if err := wafBreaker.Allow(); err != nil {
-		writeError(w, http.StatusServiceUnavailable, "WAF service circuit open — retrying soon")
-		return
-	}
-	resp, err := wafGet(h.cfg, "/stats")
+	resp, err := wafGetBreaker(r.Context(), h.cfg, "/stats")
 	if err != nil {
-		wafBreaker.RecordFailure()
-		writeError(w, http.StatusBadGateway, "WAF service unreachable")
+		if errors.Is(err, appMW.ErrCircuitOpen) {
+			writeError(w, http.StatusServiceUnavailable, "WAF service circuit open — retrying soon")
+		} else {
+			writeError(w, http.StatusBadGateway, "WAF service unreachable")
+		}
 		return
 	}
 	defer resp.Body.Close()
-	wafBreaker.RecordSuccess()
 	if resp.StatusCode != http.StatusOK {
 		writeError(w, http.StatusBadGateway, "WAF stats returned "+resp.Status)
 		return
@@ -513,8 +548,10 @@ func (h *AnalyticsHandlers) ResetCounters(w http.ResponseWriter, r *http.Request
 		deleted, _ = res.RowsAffected()
 	}
 
+	// The log delete above is unconditional; the WAF reset is best-effort and
+	// behind the breaker, so a down/circuit-open WAF can't gate the DB clear.
 	wafReset := false
-	if resp, err := wafPost(h.cfg, "/reset", "application/json", nil); err == nil {
+	if resp, err := wafPostBreaker(r.Context(), h.cfg, "/reset", "application/json", nil); err == nil {
 		resp.Body.Close()
 		wafReset = resp.StatusCode == 200
 	}
@@ -615,8 +652,11 @@ func (h *AnalyticsHandlers) DashboardSummary(w http.ResponseWriter, r *http.Requ
 	}
 	result["recent_blocks"] = recentBlocks
 
-	// WAF stats
-	if resp, err := wafGet(h.cfg, "/stats"); err == nil {
+	// WAF stats — behind the circuit breaker so a down or circuit-open WAF
+	// degrades only this sub-field (and counts toward tripping the breaker)
+	// instead of blocking every dashboard load for the full client timeout. The
+	// rest of the dashboard is DB-sourced and must still render.
+	if resp, err := wafGetBreaker(r.Context(), h.cfg, "/stats"); err == nil {
 		if resp.StatusCode == http.StatusOK {
 			var wafData any
 			json.NewDecoder(resp.Body).Decode(&wafData) //nolint:errcheck
@@ -842,17 +882,15 @@ func (h *AnalyticsHandlers) AuditLog(w http.ResponseWriter, r *http.Request) {
 
 // WAFCategories proxies GET /categories from the WAF container.
 func (h *AnalyticsHandlers) WAFCategories(w http.ResponseWriter, r *http.Request) {
-	if err := wafBreaker.Allow(); err != nil {
-		writeError(w, http.StatusServiceUnavailable, "WAF circuit open")
-		return
-	}
-	resp, err := wafGet(h.cfg, "/categories")
+	resp, err := wafGetBreaker(r.Context(), h.cfg, "/categories")
 	if err != nil {
-		wafBreaker.RecordFailure()
-		writeError(w, http.StatusBadGateway, "WAF unreachable")
+		if errors.Is(err, appMW.ErrCircuitOpen) {
+			writeError(w, http.StatusServiceUnavailable, "WAF circuit open")
+		} else {
+			writeError(w, http.StatusBadGateway, "WAF unreachable")
+		}
 		return
 	}
-	wafBreaker.RecordSuccess()
 	defer resp.Body.Close()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)
@@ -861,17 +899,15 @@ func (h *AnalyticsHandlers) WAFCategories(w http.ResponseWriter, r *http.Request
 
 // WAFCategoryToggle proxies POST /categories/toggle to WAF.
 func (h *AnalyticsHandlers) WAFCategoryToggle(w http.ResponseWriter, r *http.Request) {
-	if err := wafBreaker.Allow(); err != nil {
-		writeError(w, http.StatusServiceUnavailable, "WAF circuit open")
-		return
-	}
-	resp, err := wafPost(h.cfg, "/categories/toggle", "application/json", r.Body)
+	resp, err := wafPostBreaker(r.Context(), h.cfg, "/categories/toggle", "application/json", r.Body)
 	if err != nil {
-		wafBreaker.RecordFailure()
-		writeError(w, http.StatusBadGateway, "WAF unreachable")
+		if errors.Is(err, appMW.ErrCircuitOpen) {
+			writeError(w, http.StatusServiceUnavailable, "WAF circuit open")
+		} else {
+			writeError(w, http.StatusBadGateway, "WAF unreachable")
+		}
 		return
 	}
-	wafBreaker.RecordSuccess()
 	defer resp.Body.Close()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)

--- a/backend-go/internal/handlers/analytics_extra_test.go
+++ b/backend-go/internal/handlers/analytics_extra_test.go
@@ -7,7 +7,53 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	appMW "github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/middleware"
 )
+
+// TestDashboardSummary_WAFBreakerDegrades verifies that when the WAF is down the
+// dashboard's /stats fan-out degrades to waf=nil (never 500s), counts toward the
+// breaker, and short-circuits fast once the breaker is open instead of hanging
+// for the client timeout on every load.
+func TestDashboardSummary_WAFBreakerDegrades(t *testing.T) {
+	db, _, cfg, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Isolate from the package-level singleton and restore it afterwards.
+	wafBreaker = appMW.NewCircuitBreaker(3, 30*time.Second)
+	defer func() { wafBreaker = appMW.NewCircuitBreaker(3, 30*time.Second) }()
+
+	// Closed port → connection refused fast (not the 3s client timeout).
+	cfg.WAFURL = "http://127.0.0.1:1"
+	h := NewAnalyticsHandlers(db, cfg, &mockDockerClient{})
+
+	for i := 0; i < 5; i++ {
+		r := httptest.NewRequest("GET", "/api/dashboard/summary", nil)
+		w := httptest.NewRecorder()
+		start := time.Now()
+		h.DashboardSummary(w, r)
+		elapsed := time.Since(start)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("iter %d: dashboard must stay 200 with WAF down, got %d", i, w.Code)
+		}
+		var resp struct {
+			Data map[string]any `json:"data"`
+		}
+		_ = json.NewDecoder(w.Body).Decode(&resp)
+		if v, ok := resp.Data["waf"]; !ok || v != nil {
+			t.Errorf("iter %d: expected waf=nil with WAF down, got %v (present=%v)", i, v, ok)
+		}
+		if elapsed > 2*time.Second {
+			t.Errorf("iter %d: dashboard hung %v — breaker not short-circuiting?", i, elapsed)
+		}
+	}
+
+	if wafBreaker.State() != appMW.CircuitOpen {
+		t.Errorf("breaker should be open after repeated WAF failures, state=%v", wafBreaker.State())
+	}
+}
 
 func TestAnalyticsHandlers_Status_Mocked(t *testing.T) {
 	db, _, cfg, cleanup := setupTestDB(t)
@@ -108,25 +154,33 @@ func TestAnalyticsHandlers_MoreStats(t *testing.T) {
 	r := httptest.NewRequest("GET", "/api/analytics/shadow-it", nil)
 	w := httptest.NewRecorder()
 	h.ShadowIT(w, r)
-	if w.Code != http.StatusOK { t.Errorf("ShadowIT failed: %d", w.Code) }
+	if w.Code != http.StatusOK {
+		t.Errorf("ShadowIT failed: %d", w.Code)
+	}
 
 	// 2. UserAgents (actually counts methods)
 	r = httptest.NewRequest("GET", "/api/analytics/user-agents", nil)
 	w = httptest.NewRecorder()
 	h.UserAgents(w, r)
-	if w.Code != http.StatusOK { t.Errorf("UserAgents failed: %d", w.Code) }
+	if w.Code != http.StatusOK {
+		t.Errorf("UserAgents failed: %d", w.Code)
+	}
 
 	// 3. FileExtensions
 	r = httptest.NewRequest("GET", "/api/analytics/file-extensions", nil)
 	w = httptest.NewRecorder()
 	h.FileExtensions(w, r)
-	if w.Code != http.StatusOK { t.Errorf("FileExtensions failed: %d", w.Code) }
+	if w.Code != http.StatusOK {
+		t.Errorf("FileExtensions failed: %d", w.Code)
+	}
 
 	// 4. TopDomains
 	r = httptest.NewRequest("GET", "/api/analytics/top-domains", nil)
 	w = httptest.NewRecorder()
 	h.TopDomains(w, r)
-	if w.Code != http.StatusOK { t.Errorf("TopDomains failed: %d", w.Code) }
+	if w.Code != http.StatusOK {
+		t.Errorf("TopDomains failed: %d", w.Code)
+	}
 }
 
 func TestAnalyticsHandlers_TestRule_Extra(t *testing.T) {
@@ -141,12 +195,16 @@ func TestAnalyticsHandlers_TestRule_Extra(t *testing.T) {
 	r := httptest.NewRequest("POST", "/api/waf/test-rule", bytes.NewBuffer(body))
 	w := httptest.NewRecorder()
 	h.TestRule(w, r)
-	if w.Code != http.StatusOK { t.Errorf("TestRule failed: %d", w.Code) }
+	if w.Code != http.StatusOK {
+		t.Errorf("TestRule failed: %d", w.Code)
+	}
 
 	// Invalid regex
 	body, _ = json.Marshal(map[string]any{"regex": "[invalid", "hours": 24})
 	r = httptest.NewRequest("POST", "/api/waf/test-rule", bytes.NewBuffer(body))
 	w = httptest.NewRecorder()
 	h.TestRule(w, r)
-	if w.Code != http.StatusBadRequest { t.Errorf("Expected 400 for invalid regex, got %d", w.Code) }
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400 for invalid regex, got %d", w.Code)
+	}
 }


### PR DESCRIPTION
**Wave 2 — PR 4 of 6.** Closes a circuit-breaker coverage gap on the hottest endpoint.

### Problem
`DashboardSummary` polled the WAF `/stats` with a bare `wafGet` — **outside** the
circuit breaker that already guarded the dedicated WAF endpoints. So when the WAF
was down, every `/api/dashboard/summary` (the most frequently polled endpoint)
still made a real HTTP call and blocked for the full 3s client timeout before
falling back to `waf=nil`, and those failures never counted toward tripping the
breaker. `ResetCounters`' `/reset` had the same gap.

### Change
- Unified the breaker boilerplate into `wafGetBreaker` / `wafPostBreaker` so no
  call site can drift out of coverage again; routed WAFStats, WAFCategories,
  WAFCategoryToggle, the dashboard `/stats` fan-out, and ResetCounters' `/reset`
  through them. `ErrCircuitOpen` → 503, transport error → 502 (preserved).
- DashboardSummary degrades only the `waf` sub-field to `nil`; the DB-sourced rest
  of the dashboard always renders (never 500).
- ResetCounters keeps `DELETE FROM proxy_logs` **unconditional** — the breaker
  wraps only the best-effort WAF reset, so a down WAF can't skip the log clear.
- `wafGet`/`wafPost` now use `http.NewRequestWithContext(r.Context())`, so a client
  disconnect cancels the upstream call instead of leaking it.

### Verification
- New test: WAF pointed at a closed port → dashboard stays 200 with `waf=nil`, the
  breaker opens after repeated failures, and once open the call short-circuits fast
  (no per-load 3s hang). Existing WAF-proxying tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)