### PR TITLE
feat(waf): correlation event-ID per inspected request (Wave 2, 5a)

### DIFF
--- a/waf-go/entropy.go
+++ b/waf-go/entropy.go
@@ -42,6 +42,7 @@ func shannonEntropy(s string) float64 {
 // ── Traffic Feature Extraction ──────────────────────────────────────────────
 
 type TrafficFeature struct {
+	EventID         string   `json:"event_id"`
 	Timestamp       string   `json:"ts"`
 	ClientIP        string   `json:"client_ip"`
 	Method          string   `json:"method"`

--- a/waf-go/entropy_test.go
+++ b/waf-go/entropy_test.go
@@ -1,10 +1,29 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestNextEventID(t *testing.T) {
+	t0 := time.Now()
+	a := nextEventID(t0)
+	b := nextEventID(t0) // same timestamp — the atomic counter must still differ
+	if a == "" || b == "" {
+		t.Fatal("event id must not be empty")
+	}
+	if a == b {
+		t.Errorf("event ids must be unique at the same timestamp: %q == %q", a, b)
+	}
+	// The ID rides along in the JSONL traffic record so a block can be traced.
+	js, _ := json.Marshal(TrafficFeature{EventID: a, Method: "GET"})
+	if !strings.Contains(string(js), `"event_id":"`+a+`"`) {
+		t.Errorf("event_id missing from TrafficFeature JSON: %s", js)
+	}
+}
 
 func TestShannonEntropy(t *testing.T) {
 	cases := []struct {

--- a/waf-go/main.go
+++ b/waf-go/main.go
@@ -258,6 +258,17 @@ func handleOptions(w icap.ResponseWriter, req *icap.Request) {
 	w.WriteHeader(200, nil, false)
 }
 
+var eventCounter uint64
+
+// nextEventID returns a process-unique, time-ordered correlation ID for one
+// inspected request: base-36 nanos + an atomic counter. Cheap on the
+// latency-tracked hot path (no crypto/rand). It ties a block's WAF traffic-log
+// record to the notification/websocket event the backend emits for it.
+func nextEventID(t time.Time) string {
+	n := atomic.AddUint64(&eventCounter, 1)
+	return strconv.FormatInt(t.UnixNano(), 36) + "-" + strconv.FormatUint(n, 36)
+}
+
 func handleReqmod(w icap.ResponseWriter, req *icap.Request) {
 	if req.Request == nil || req.Request.URL == nil {
 		w.WriteHeader(204, nil, false)
@@ -265,6 +276,7 @@ func handleReqmod(w icap.ResponseWriter, req *icap.Request) {
 	}
 
 	startTime := time.Now()
+	eventID := nextEventID(startTime)
 
 	rawURL := req.Request.URL.String()
 
@@ -387,6 +399,7 @@ func handleReqmod(w icap.ResponseWriter, req *icap.Request) {
 	}
 
 	feature := TrafficFeature{
+		EventID:         eventID,
 		Timestamp:       startTime.UTC().Format(time.RFC3339),
 		ClientIP:        clientIP,
 		Method:          req.Request.Method,
@@ -496,6 +509,7 @@ func handleReqmod(w icap.ResponseWriter, req *icap.Request) {
 			"event_type": "waf_block",
 			"message":    fmt.Sprintf("WAF blocked %s — score %d, categories: %s", source, score, strings.Join(categories, ", ")),
 			"details": map[string]interface{}{
+				"event_id":   eventID,
 				"category":   primaryCategory,
 				"categories": categories,
 				"rules":      ruleIDs,


### PR DESCRIPTION
**Wave 2 — PR 5 of 6** (part 5a). Correlation ID across the WAF's own artifacts.

### Problem
The WAF sees a block's full verdict but emitted three **ID-less** artifacts — the
403 page, the `/data/waf_traffic.jsonl` record, and the backend alert — so a block
could only be correlated by the fuzzy `(client_ip, url, ~timestamp)` tuple, which
collides under concurrency.

### Change
Mint one `event_id` per inspected request in `handleReqmod` (monotonic base-36
nanos + atomic counter — no `crypto/rand` on the latency-tracked hot path), threaded
through:
- `TrafficFeature.event_id` → every JSONL traffic record;
- the alert `details` map → the backend's `ReceiveAlert` already flattens `details`
  into the notification/websocket event, so `event_id` reaches all notifiers + the
  live feed **with zero backend model changes**.

Links **WAF traffic log ↔ notification ↔ live feed**.

### Deferred (tracked in #107)
Extending the same ID to the Squid access log → `proxy_logs` row needs a custom Squid
`logformat`, which risks the positional parse of *every* log line and the correct
header logformat code is ICAP-stack-specific — so it needs **live CT130 verification**,
not just CI. Documented with caveats in #107.

### Verification
- `go test ./...` green in waf-go; `nextEventID` is unique even at an identical
  timestamp and serializes into the `TrafficFeature` JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)