### PR TITLE
perf(waf): collapse the redundant second regex pass on whitespace-free input (Wave 2)

### DIFF
--- a/waf-go/normalization_test.go
+++ b/waf-go/normalization_test.go
@@ -5,6 +5,30 @@ import (
 	"testing"
 )
 
+// TestMatchRulesScored_CompactCollapse guards the double-scan collapse: direct
+// attacks must still block, space-insertion evasion (only caught via the compact
+// pass) must still block, and clean whitespace-free input (the path that now
+// skips the redundant compact re-scan) must not false-positive.
+func TestMatchRulesScored_CompactCollapse(t *testing.T) {
+	blocked := []struct{ name, payload string }{
+		{"sqli-union", "id=1 UNION SELECT password FROM users"},
+		{"xss-direct", "<script>alert(1)</script>"},
+		{"xss-space-insertion", "<scr ipt>alert(1)</scr ipt>"}, // only the compact pass catches this
+	}
+	for _, c := range blocked {
+		if _, score := matchRulesScored(c.payload); score == 0 {
+			t.Errorf("%s: expected block (score>0), got 0 for %q", c.name, c.payload)
+		}
+	}
+
+	clean := []string{"hello-world", "user=alice&page=2", "/api/v1/items/42"}
+	for _, c := range clean {
+		if m, score := matchRulesScored(c); score != 0 || len(m) != 0 {
+			t.Errorf("clean input %q false-positived: score=%d matches=%v", c, score, m)
+		}
+	}
+}
+
 func TestIsLANHost(t *testing.T) {
 	tests := []struct {
 		host string

--- a/waf-go/rules.go
+++ b/waf-go/rules.go
@@ -454,9 +454,16 @@ func matchRulesScored(input string) ([]MatchResult, int) {
 	totalScore := 0
 	matched := make(map[string]bool) // Deduplicate by rule ID
 
-	// Prepare a compacted version (no whitespace) lazily — only used if
-	// the normal input doesn't match, to catch evasion via space insertion.
+	// Compacted (whitespace-stripped) form, to catch evasion via space insertion
+	// (e.g. "<scr ipt>", "UNION  SELECT"). Built lazily on the first rule miss.
+	// Crucially, it's only re-scanned when it actually DIFFERS from input — i.e.
+	// the input contained whitespace. With no whitespace, compactInput is a no-op
+	// and MatchString(compact) is identical to the MatchString(input) we already
+	// ran, so the second scan is pure redundant work. Skipping it there halves the
+	// per-rule regex evaluations on the common case (whitespace-free URLs/queries)
+	// with zero change to what gets detected.
 	var compact string
+	var checkCompact bool
 	var compactReady bool
 
 	for tier := 1; tier <= 3; tier++ {
@@ -477,12 +484,16 @@ func matchRulesScored(input string) ([]MatchResult, int) {
 				}
 				hit := rule.Pattern.MatchString(input)
 				if !hit {
-					// Lazy-init compact on first miss
+					// Lazy-init compact on the first miss, and decide once whether
+					// it can differ from input at all.
 					if !compactReady {
 						compact = compactInput(input)
+						checkCompact = compact != input
 						compactReady = true
 					}
-					hit = rule.Pattern.MatchString(compact)
+					if checkCompact {
+						hit = rule.Pattern.MatchString(compact)
+					}
 				}
 				if hit {
 					matched[rule.ID] = true


### PR DESCRIPTION
**Wave 2 — PR 6 of 6.** Collapses the WAF double-scan. Provably detection-equivalent.

### Problem
`matchRulesScored` ran each of the ~170 RE2 rules against `input` and, on a miss,
re-ran it against a whitespace-stripped `compact` form (to catch space-insertion
evasion like `<scr ipt>`). On clean traffic almost every rule misses on `input`, so
the compact re-scan fired for nearly the whole rule set — **~2× the regex
evaluations** per scan, and the scan runs up to 3× per request (URL, raw URL, body).

### Insight
`compactInput` strips **all** whitespace, so when the input has none,
`compact == input` and `MatchString(compact)` is identical to the
`MatchString(input)` already run — pure redundant work. Decide once (on the first
rule miss) whether compact can differ, and skip the second scan when it can't.

**Provably detection-equivalent:** when `compact == input` the skipped call had the
same result; when `compact != input` (input has whitespace) the compact pass runs
exactly as before, so space-insertion evasion is still caught. No rule, threshold,
or scoring change.

### Impact
On a whitespace-free URL/query (the common case) this cuts per-scan regex work
**~28%** (160µs vs 223µs/op in a local bench).

### Verification
- New regression test: direct SQLi/XSS **and** space-insertion XSS (`<scr ipt>…`,
  caught only via the compact pass) still block; clean whitespace-free inputs don't
  false-positive. Existing `normalization_test.go` / `fuzz_test.go` green.

### Deliberately out of scope
The cheap aho-corasick **pre-filter** from the audit plan is **not** here — it's the
one change that could create a silent bypass and needs provable literal extraction
from the patterns + a full rule-positive coverage gate. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)