### PR TITLE
release: v3.7.0 — Wave 2 (performance & observability)

### DIFF
--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.6.4"
+const AppVersion = "3.7.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.6.4",
+  "version": "3.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump 3.6.4 → 3.7.0 for **Wave 2 — performance & observability**.

Ships (all merged):
- **#103** remove the broken H5 header-morphing heuristic (fingerprinted Go's random map iteration)
- **#104** indexed `blocked` flag replacing `LIKE '%DENIED%'` full scans (+ migration that surfaced & fixed an upgrade-ordering blocker)
- **#105** `unix_timestamp` range scans (dead index now live) + bounded the unbounded analytics GROUP BY windows
- **#106** dashboard WAF `/stats` fan-out brought inside the circuit breaker + request-context cancellation
- **#108** correlation event-ID minted per inspected request, threaded through the WAF traffic log + notification/websocket (5a)
- **#109** collapsed the redundant second regex pass on whitespace-free input (~28% less per-scan regex work, provably detection-equivalent)

Follow-ups tracked: #102 (WAF heuristic-toggle wiring), #107 (event-ID → Squid access log/proxy_logs, 5b), #110 (aho-corasick pre-filter).

Bumps `backend-go/internal/config/version.go` and `ui/package.json`. Tag + GitHub release on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)