### PR TITLE
feat(ui): modal focus-trap + Escape + focus-restore (Wave 3)

### DIFF
--- a/ui/src/components/GlobalSearch.tsx
+++ b/ui/src/components/GlobalSearch.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Search, ArrowRight, Ban, Shield, List, Settings, LayoutDashboard, X } from 'lucide-react';
 import { api } from '../lib/api';
+import { useModal } from '../hooks/useModal';
 import type { IpEntry, DomainEntry, LogEntry } from '../types';
 
 interface SearchResult {
@@ -27,6 +28,9 @@ export function GlobalSearch() {
   const [loading, setLoading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
+  // Focus-trap + restore + Escape for the search dialog. (Cmd+K to OPEN stays a
+  // global shortcut below; only the in-dialog Escape moves to the hook.)
+  const dialogRef = useModal<HTMLDivElement>(open, () => setOpen(false));
 
   // Cmd+K / Ctrl+K to open
   useEffect(() => {
@@ -35,7 +39,7 @@ export function GlobalSearch() {
         e.preventDefault();
         setOpen(o => !o);
       }
-      if (e.key === 'Escape') setOpen(false);
+      // Escape-to-close is handled by useModal (scoped to the open dialog).
       // Number keys for navigation (only when search is closed)
       if (!open && !e.metaKey && !e.ctrlKey && !e.altKey) {
         const target = e.target as HTMLElement;
@@ -58,7 +62,8 @@ export function GlobalSearch() {
         setQuery('');
         setResults([]);
         setSelected(0);
-        inputRef.current?.focus();
+        // Initial focus is handled by useModal (focuses the first focusable —
+        // the search input).
       }, 0);
     }
   }, [open]);
@@ -163,6 +168,7 @@ export function GlobalSearch() {
       <h2 id="global-search-title" className="sr-only">Global search</h2>
       <div className="fixed inset-0 bg-black/50 -webkit-backdrop-blur-xl backdrop-blur-xl" aria-hidden="true" />
       <div
+        ref={dialogRef}
         className="relative w-full max-w-lg glass-surface rounded-2xl shadow-2xl overflow-hidden animate-fade-in-up"
         onClick={e => e.stopPropagation()}
       >

--- a/ui/src/components/SetupWizard.tsx
+++ b/ui/src/components/SetupWizard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Shield, Baby, Server, Lock, Monitor, Tv, Wifi, Smartphone, ChevronRight, ChevronLeft, Zap, Check } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { api } from '../lib/api';
+import { useModal } from '../hooks/useModal';
 
 interface Props {
   onComplete: () => void;
@@ -107,6 +108,8 @@ export function SetupWizard({ onComplete }: Props) {
   const [devices, setDevices] = useState<string[]>([]);
   const [strict, setStrict] = useState<StrictLevel>('balanced');
   const [saving, setSaving] = useState(false);
+  // First-run gate: trap focus inside the wizard, but no Escape-to-dismiss.
+  const modalRef = useModal<HTMLDivElement>(true);
 
   const toggleDevice = (id: string) => {
     setDevices(prev => prev.includes(id) ? prev.filter(d => d !== id) : [...prev, id]);
@@ -156,6 +159,7 @@ export function SetupWizard({ onComplete }: Props) {
 
   return (
     <div
+      ref={modalRef}
       className="fixed inset-0 z-[100] bg-background flex items-center justify-center p-4"
       role="dialog"
       aria-modal="true"

--- a/ui/src/hooks/useModal.test.tsx
+++ b/ui/src/hooks/useModal.test.tsx
@@ -1,0 +1,36 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useModal } from './useModal';
+
+function Dialog({ open, onClose }: { open: boolean; onClose?: () => void }) {
+  const ref = useModal<HTMLDivElement>(open, onClose);
+  if (!open) return null;
+  return (
+    <div ref={ref} role="dialog">
+      <button>one</button>
+      <button>two</button>
+    </div>
+  );
+}
+
+describe('useModal', () => {
+  it('closes on Escape when onClose is provided', () => {
+    const onClose = vi.fn();
+    render(<Dialog open onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('is inert on Escape when no onClose is given (non-dismissible gate)', () => {
+    render(<Dialog open />);
+    // Must not throw.
+    expect(() => fireEvent.keyDown(document, { key: 'Escape' })).not.toThrow();
+  });
+
+  it('does nothing when closed', () => {
+    const onClose = vi.fn();
+    render(<Dialog open={false} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/hooks/useModal.ts
+++ b/ui/src/hooks/useModal.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Wires modal accessibility onto a dialog container: focuses the first focusable
+ * element on open, traps Tab/Shift+Tab within it, closes on Escape, and restores
+ * focus to whatever was focused before it opened (WCAG 2.4.3 / 2.1.2).
+ *
+ * Attach the returned ref to the dialog's content element. Pass `onClose` to
+ * enable Escape-to-close; omit it for a non-dismissible gate (e.g. first-run
+ * wizard) — focus is still trapped, Escape just does nothing.
+ */
+export function useModal<T extends HTMLElement>(isOpen: boolean, onClose?: () => void) {
+  const ref = useRef<T>(null);
+  const restoreRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const container = ref.current;
+    restoreRef.current = (document.activeElement as HTMLElement) ?? null;
+
+    const focusable = () =>
+      container
+        ? Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+            (el) => el.offsetParent !== null,
+          )
+        : [];
+
+    focusable()[0]?.focus();
+
+    // Listen on document so Escape closes the open modal regardless of where
+    // focus sits (and the Tab trap can pull focus back if it ever escapes the
+    // container), rather than relying on the event bubbling up from inside.
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (onClose) {
+          e.preventDefault();
+          onClose();
+        }
+        return;
+      }
+      if (e.key !== 'Tab' || !container) return;
+      const items = focusable();
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (!container.contains(document.activeElement)) {
+        e.preventDefault();
+        first.focus();
+      } else if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      restoreRef.current?.focus?.();
+    };
+  }, [isOpen, onClose]);
+
+  return ref;
+}

--- a/ui/src/pages/Clients.tsx
+++ b/ui/src/pages/Clients.tsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import { Card, CardContent } from '../components/ui/card';
 import { IpBadge } from '../components/IpBadge';
+import { useModal } from '../hooks/useModal';
 import { api } from '../lib/api';
 import type { ClientsData, ClientStat, ClientDetail } from '../types';
 
@@ -174,11 +175,12 @@ function ClientDrawer({ ip, onClose }: { ip: string; onClose: () => void }) {
   });
 
   const br = data ? rate(data.blocked, data.total_requests) : 0;
+  const modalRef = useModal<HTMLDivElement>(true, onClose);
 
   return (
     <div className="fixed inset-0 z-40 flex justify-end" role="dialog" aria-modal="true">
       <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative w-full max-w-md h-full overflow-y-auto bg-[var(--card)] border-l border-white/[0.08] shadow-2xl animate-in">
+      <div ref={modalRef} className="relative w-full max-w-md h-full overflow-y-auto bg-[var(--card)] border-l border-white/[0.08] shadow-2xl animate-in">
         <div className="sticky top-0 z-10 flex items-center justify-between px-5 py-4 border-b border-white/[0.06] bg-[var(--card)]">
           <div className="flex items-center gap-2">
             <Activity className="w-4 h-4 text-cyan-400" />


### PR DESCRIPTION
**Wave 3 — PR 3 of 6.** Real modal accessibility for the three overlays.

ClientDrawer and SetupWizard had **no Escape and no focus management**; GlobalSearch
had Escape + initial focus but **no Tab trap or focus restore**. None trapped focus,
so Tab walked straight out into the page behind (WCAG 2.4.3 / 2.1.2).

`hooks/useModal.ts`: focuses the first focusable on open, traps Tab/Shift+Tab
(pulling focus back if it escapes), closes on Escape (optional — omit `onClose` for
a non-dismissible gate), restores focus to the opener on close. Listens on
`document` so Escape works regardless of focus location.

Applied to:
- **ClientDrawer** — gains Escape + trap + restore.
- **SetupWizard** — trap only (mandatory first-run gate, no dismiss).
- **GlobalSearch** — the hook owns the in-dialog Escape + initial focus; the global
  **Cmd+K open and 1–5 page-nav shortcuts stay on the window listener, untouched**
  (the one regression risk — verified by its existing test suite).

Verification: `tsc` + lint clean; 131 vitest tests pass incl. a new useModal test
and the unchanged GlobalSearch/SetupWizard/Clients suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)