### PR TITLE
feat(ui): screen-reader alternatives for charts (Wave 3)

### DIFF
--- a/ui/src/components/dashboard/DashboardCharts.tsx
+++ b/ui/src/components/dashboard/DashboardCharts.tsx
@@ -2,6 +2,7 @@ import { Area, Bar, ComposedChart, ResponsiveContainer, Tooltip, XAxis, YAxis, C
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { AlertTriangle } from 'lucide-react';
 import type { TimelineEntry, DashboardSummary } from '../../types';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
 
 const C = ['#ef4444', '#f97316', '#eab308', '#3b82f6', '#8b5cf6', '#06b6d4', '#10b981', '#ec4899'];
 
@@ -26,6 +27,9 @@ interface Props {
 // route bundle (~110 KB gzipped) for users who land on /dashboard but never
 // scroll to the charts.
 export default function DashboardCharts({ chart, summary }: Props) {
+  const reducedMotion = useReducedMotion();
+  const totalReqs = chart.reduce((s, p) => s + (p.total || 0), 0);
+  const blockedReqs = chart.reduce((s, p) => s + (p.blocked || 0), 0);
   return (
     <div className="grid gap-3 lg:grid-cols-12">
       {/* Traffic chart */}
@@ -34,7 +38,7 @@ export default function DashboardCharts({ chart, summary }: Props) {
           <CardTitle className="text-sm">Traffic 24h</CardTitle>
         </CardHeader>
         <CardContent className="p-2">
-          <div className="h-[180px]">
+          <div className="h-[180px]" role="img" aria-label={`Traffic over the last 24 hours: ${totalReqs} requests, ${blockedReqs} blocked`}>
             <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
               <ComposedChart data={chart} margin={{ top: 5, right: 10, left: -20, bottom: 0 }}>
                 <defs>
@@ -44,8 +48,8 @@ export default function DashboardCharts({ chart, summary }: Props) {
                 <YAxis yAxisId="left" stroke="#555" fontSize={9} tickLine={false} axisLine={false} />
                 <YAxis yAxisId="right" orientation="right" stroke="#ef4444" fontSize={9} tickLine={false} axisLine={false} />
                 <Tooltip contentStyle={TOOLTIP_STYLE} />
-                <Area yAxisId="left" type="monotone" dataKey="total" name="Total" stroke="#3b82f6" strokeWidth={1.5} fill="url(#cT)" />
-                <Bar yAxisId="right" dataKey="blocked" name="Blocked" fill="#ef4444" opacity={0.7} radius={[2, 2, 0, 0]} />
+                <Area yAxisId="left" type="monotone" dataKey="total" name="Total" stroke="#3b82f6" strokeWidth={1.5} fill="url(#cT)" isAnimationActive={!reducedMotion} />
+                <Bar yAxisId="right" dataKey="blocked" name="Blocked" fill="#ef4444" opacity={0.7} radius={[2, 2, 0, 0]} isAnimationActive={!reducedMotion} />
               </ComposedChart>
             </ResponsiveContainer>
           </div>
@@ -60,9 +64,9 @@ export default function DashboardCharts({ chart, summary }: Props) {
         <CardContent className="p-2">
           {(summary?.threat_categories?.length ?? 0) > 0 && summary ? (
             <>
-              <div className="h-[130px]">
+              <div className="h-[130px]" role="img" aria-label={`Threat categories: ${summary.threat_categories.map(c => `${c.category} ${c.count}`).join(', ')}`}>
                 <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
-                  <PieChart><Pie data={summary.threat_categories} dataKey="count" nameKey="category" cx="50%" cy="50%" innerRadius={35} outerRadius={55} paddingAngle={3}>
+                  <PieChart><Pie data={summary.threat_categories} dataKey="count" nameKey="category" cx="50%" cy="50%" innerRadius={35} outerRadius={55} paddingAngle={3} isAnimationActive={!reducedMotion}>
                     {summary.threat_categories.map((_: unknown, i: number) => <Cell key={i} fill={C[i % C.length]} />)}
                   </Pie><Tooltip contentStyle={TOOLTIP_STYLE} /></PieChart>
                 </ResponsiveContainer>

--- a/ui/src/pages/ThreatIntel.tsx
+++ b/ui/src/pages/ThreatIntel.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { useEffect, useState } from 'react';
 import { useAnimatedNumber } from '../hooks/useAnimatedNumber';
+import { useReducedMotion } from '../hooks/useReducedMotion';
 import type { TimelineEntry, DashboardSummary, ShadowItService, FileExtData, ServiceTypeData, TopDomain } from '../types';
 import { RegexPlayground } from '../components/RegexPlayground';
 
@@ -26,6 +27,7 @@ const TOOLTIP_STYLE = {
 };
 
 export function ThreatIntel() {
+  const reducedMotion = useReducedMotion();
   const [vis, setVis] = useState(document.visibilityState !== 'hidden');
   useEffect(() => { const h = () => setVis(document.visibilityState !== 'hidden'); document.addEventListener('visibilitychange', h); return () => document.removeEventListener('visibilitychange', h); }, []);
 
@@ -37,6 +39,8 @@ export function ThreatIntel() {
   const { data: uaData } = useQuery<ServiceTypeData>({ queryKey: ['user-agents'], queryFn: () => api.get('analytics/user-agents').then(r => r.data.data), refetchInterval: vis ? 60_000 : false });
 
   const wafCats = s?.waf?.top_blocked_categories ?? [];
+  const tlTotal = (tl ?? []).reduce((acc, p) => acc + (p.total || 0), 0);
+  const tlBlocked = (tl ?? []).reduce((acc, p) => acc + (p.blocked || 0), 0);
 
   const animTodayBlocked = useAnimatedNumber(s?.today_blocked ?? 0);
   const animTotalBlocked = useAnimatedNumber(s?.blocked_requests ?? 0);
@@ -87,15 +91,15 @@ export function ThreatIntel() {
         <Card className="lg:col-span-7">
           <CardHeader className="p-3 pb-0"><CardTitle className="text-sm">Threat Timeline (72h)</CardTitle></CardHeader>
           <CardContent className="p-2">
-            <div className="h-[180px]">
+            <div className="h-[180px]" role="img" aria-label={`Threat timeline over the last 72 hours: ${tlTotal} total events, ${tlBlocked} blocked`}>
               <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                 <AreaChart data={tl ?? []} margin={{ top: 5, right: 10, left: -20, bottom: 0 }}>
                   <defs><linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="#ef4444" stopOpacity={0.4}/><stop offset="95%" stopColor="#ef4444" stopOpacity={0}/></linearGradient></defs>
                   <XAxis dataKey="time" stroke="#555" fontSize={9} tickLine={false} axisLine={false} />
                   <YAxis stroke="#555" fontSize={9} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={TOOLTIP_STYLE} />
-                  <Area type="monotone" dataKey="blocked" name="Blocked" stroke="#ef4444" strokeWidth={2} fill="url(#bg)" />
-                  <Area type="monotone" dataKey="total" name="Total" stroke="#3b82f6" strokeWidth={1} fill="none" opacity={0.4} />
+                  <Area type="monotone" dataKey="blocked" name="Blocked" stroke="#ef4444" strokeWidth={2} fill="url(#bg)" isAnimationActive={!reducedMotion} />
+                  <Area type="monotone" dataKey="total" name="Total" stroke="#3b82f6" strokeWidth={1} fill="none" opacity={0.4} isAnimationActive={!reducedMotion} />
                 </AreaChart>
               </ResponsiveContainer>
             </div>
@@ -106,13 +110,13 @@ export function ThreatIntel() {
           <CardHeader className="p-3 pb-0"><CardTitle className="text-sm">WAF Categories</CardTitle></CardHeader>
           <CardContent className="p-2">
             {wafCats.length > 0 ? (
-              <div className="h-[180px]">
+              <div className="h-[180px]" role="img" aria-label={`Top WAF blocked categories: ${wafCats.slice(0, 8).map(c => `${c.key} ${c.count}`).join(', ')}`}>
                 <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                   <BarChart data={wafCats.slice(0, 8)} layout="vertical" margin={{ left: 80, right: 10 }}>
                     <XAxis type="number" stroke="#555" fontSize={9} tickLine={false} />
                     <YAxis type="category" dataKey="key" stroke="#555" fontSize={9} tickLine={false} width={80} />
                     <Tooltip contentStyle={TOOLTIP_STYLE} />
-                    <Bar dataKey="count" radius={[0, 3, 3, 0]}>{wafCats.slice(0, 8).map((_: unknown, i: number) => <Cell key={i} fill={C[i % C.length]} />)}</Bar>
+                    <Bar dataKey="count" radius={[0, 3, 3, 0]} isAnimationActive={!reducedMotion}>{wafCats.slice(0, 8).map((_: unknown, i: number) => <Cell key={i} fill={C[i % C.length]} />)}</Bar>
                   </BarChart>
                 </ResponsiveContainer>
               </div>
@@ -152,9 +156,9 @@ export function ThreatIntel() {
           <CardContent className="p-2">
             {(fileExts?.categories?.length ?? 0) > 0 ? (
               <>
-                <div className="h-[120px]">
+                <div className="h-[120px]" role="img" aria-label={`File types: ${fileExts!.categories.slice(0, 8).map(c => `${c.category} ${c.count}`).join(', ')}`}>
                   <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
-                    <PieChart><Pie data={fileExts!.categories.slice(0, 8)} dataKey="count" nameKey="category" cx="50%" cy="50%" innerRadius={30} outerRadius={50} paddingAngle={2}>
+                    <PieChart><Pie data={fileExts!.categories.slice(0, 8)} dataKey="count" nameKey="category" cx="50%" cy="50%" innerRadius={30} outerRadius={50} paddingAngle={2} isAnimationActive={!reducedMotion}>
                       {fileExts!.categories.slice(0, 8).map((_, i) => <Cell key={i} fill={C[i % C.length]} />)}
                     </Pie><Tooltip contentStyle={TOOLTIP_STYLE} /></PieChart>
                   </ResponsiveContainer>


### PR DESCRIPTION
**Wave 3 — PR 4 of 6.** Makes the 5 recharts charts accessible.

The charts (Dashboard traffic + threats pie; ThreatIntel timeline + WAF bar +
file-types pie) gave screen-reader users nothing — the SVG had no role, label, or
text alternative (WCAG 1.1.1).

- Each chart's height container gets `role="img"` + a **data-derived `aria-label`**
  summarizing the series ("Traffic over the last 24 hours: N requests, M blocked";
  category charts list their category/count pairs). `role="img"` also hides the SVG
  subtree from AT. The pies keep their visible legend chips as extra detail.
- `isAnimationActive={!reducedMotion}` on every series, so chart mount animation is
  skipped under reduced motion (completes the #113 foundation).

Verification: `tsc` + lint clean; 134 vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)