### PR TITLE
feat(ui): shared confirmation dialog for destructive actions (Wave 3)

### DIFF
--- a/ui/src/components/settings/Maintenance.tsx
+++ b/ui/src/components/settings/Maintenance.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../ui
 import { Database, Download, Trash2, RotateCcw, Wrench } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { api } from '../../lib/api';
+import { useConfirm } from '../../hooks/useConfirm';
 
 function Btn({ icon: Icon, label, sub, onClick, destructive }: {
   icon: typeof Download; label: string; sub: string; onClick: () => void; destructive?: boolean;
@@ -24,6 +25,7 @@ function Btn({ icon: Icon, label, sub, onClick, destructive }: {
 }
 
 export function Maintenance() {
+  const { confirm, dialog } = useConfirm();
   const action = async (label: string, fn: () => Promise<unknown>) => {
     const id = toast.loading(`${label}...`);
     try {
@@ -42,14 +44,31 @@ export function Maintenance() {
     a.click(); window.URL.revokeObjectURL(url);
   });
 
-  const handleClearCache = () => action('Clear cache', () => api.post('maintenance/clear-cache'));
+  const handleClearCache = async () => {
+    if (!(await confirm({
+      title: 'Clear proxy cache?',
+      body: 'Frees proxy memory now; cached objects are re-fetched on the next request.',
+      confirmLabel: 'Clear cache',
+      destructive: true,
+    }))) return;
+    action('Clear cache', () => api.post('maintenance/clear-cache'));
+  };
   const handleOptimize = () => action('Optimize DB', () => api.post('database/optimize'));
-  const handleResetCounters = () => action('Reset counters', () => api.post('counters/reset'));
+  const handleResetCounters = async () => {
+    if (!(await confirm({
+      title: 'Reset all counters?',
+      body: 'Permanently clears all proxy logs and WAF statistics. This cannot be undone.',
+      confirmLabel: 'Reset counters',
+      destructive: true,
+    }))) return;
+    action('Reset counters', () => api.post('counters/reset'));
+  };
   const handleReloadConfig = () => action('Reload config', () => api.post('maintenance/reload-config'));
   const handleReloadDns = () => action('Reload DNS', () => api.post('maintenance/reload-dns'));
 
   return (
     <Card className="bg-card/50">
+      {dialog}
       <CardHeader className="p-4 pb-2">
         <div className="flex items-center gap-2">
           <Database className="w-4 h-4 text-muted-foreground" />

--- a/ui/src/components/ui/ConfirmDialog.tsx
+++ b/ui/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,61 @@
+import { useModal } from '../../hooks/useModal';
+
+export interface ConfirmOptions {
+  title: string;
+  body?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+}
+
+/**
+ * Accessible confirmation dialog (`role="alertdialog"`) with a focus trap, Escape
+ * to cancel, and focus restored to the trigger on close. Driven by `useConfirm`.
+ */
+export function ConfirmDialog({
+  title,
+  body,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive,
+  onConfirm,
+  onCancel,
+}: ConfirmOptions & { onConfirm: () => void; onCancel: () => void }) {
+  const ref = useModal<HTMLDivElement>(true, onCancel);
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onCancel} aria-hidden="true" />
+      <div
+        ref={ref}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="confirm-title"
+        aria-describedby={body ? 'confirm-body' : undefined}
+        className="relative w-full max-w-sm glass-surface rounded-xl border border-white/[0.08] p-5 shadow-2xl"
+      >
+        <h2 id="confirm-title" className="text-sm font-semibold">{title}</h2>
+        {body && <p id="confirm-body" className="mt-2 text-xs text-muted-foreground">{body}</p>}
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-secondary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`px-3 py-1.5 text-xs rounded-lg text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+              destructive
+                ? 'bg-destructive hover:bg-destructive/90 focus-visible:ring-destructive'
+                : 'bg-primary hover:bg-primary/90 focus-visible:ring-primary'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/hooks/useConfirm.test.tsx
+++ b/ui/src/hooks/useConfirm.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useConfirm } from './useConfirm';
+
+function Harness({ onResult }: { onResult: (v: boolean) => void }) {
+  const { confirm, dialog } = useConfirm();
+  return (
+    <div>
+      <button onClick={async () => onResult(await confirm({ title: 'Reset counters?', destructive: true, confirmLabel: 'Reset' }))}>
+        trigger
+      </button>
+      {dialog}
+    </div>
+  );
+}
+
+describe('useConfirm', () => {
+  it('opens an alertdialog and resolves true on confirm', async () => {
+    const onResult = vi.fn();
+    render(<Harness onResult={onResult} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    const dialog = await screen.findByRole('alertdialog', { name: 'Reset counters?' });
+    expect(dialog).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(true));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('resolves false on cancel and never fires the action', async () => {
+    const onResult = vi.fn();
+    render(<Harness onResult={onResult} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    await screen.findByRole('alertdialog');
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(false));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/hooks/useConfirm.tsx
+++ b/ui/src/hooks/useConfirm.tsx
@@ -1,0 +1,28 @@
+import { useCallback, useState } from 'react';
+import { ConfirmDialog, type ConfirmOptions } from '../components/ui/ConfirmDialog';
+
+/**
+ * Promise-based confirmation: `const { confirm, dialog } = useConfirm()`, then
+ * `if (!(await confirm({ title, body, destructive }))) return;` in a handler, and
+ * render `{dialog}` once in the component. Replaces fire-immediately destructive
+ * actions and `window.confirm` with one accessible AlertDialog.
+ */
+export function useConfirm() {
+  const [state, setState] = useState<{ opts: ConfirmOptions; resolve: (v: boolean) => void } | null>(null);
+
+  const confirm = useCallback(
+    (opts: ConfirmOptions) => new Promise<boolean>((resolve) => setState({ opts, resolve })),
+    [],
+  );
+
+  const finish = (result: boolean) => {
+    state?.resolve(result);
+    setState(null);
+  };
+
+  const dialog = state ? (
+    <ConfirmDialog {...state.opts} onConfirm={() => finish(true)} onCancel={() => finish(false)} />
+  ) : null;
+
+  return { confirm, dialog };
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { api } from '../lib/api';
 import { useAnimatedNumber } from '../hooks/useAnimatedNumber';
+import { useConfirm } from '../hooks/useConfirm';
 import type { TimelineEntry, SecurityScore, DashboardSummary, CacheStats } from '../types';
 
 // Lazy-load the recharts-based chart cards. Recharts is ~110 KB gzipped
@@ -16,6 +17,7 @@ const REFETCH = 30_000;
 
 export function Dashboard() {
   const queryClient = useQueryClient();
+  const { confirm, dialog } = useConfirm();
   const [copied, setCopied] = useState(false);
   const proxy = `${window.location.hostname}:3128`;
   const copy = () => { navigator.clipboard.writeText(proxy).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); }).catch(() => toast.error('Clipboard access denied')); };
@@ -60,6 +62,7 @@ export function Dashboard() {
 
   return (
     <div className="space-y-4">
+      {dialog}
       {/* Header + proxy address */}
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-extrabold tracking-tight bg-gradient-to-b from-white to-white/70 bg-clip-text text-transparent">Dashboard</h1>
@@ -71,7 +74,12 @@ export function Dashboard() {
             </button>
           </div>
           <button type="button" onClick={async () => {
-              if (!confirm('Reset all counters? This clears proxy logs and WAF stats.')) return;
+              if (!(await confirm({
+                title: 'Reset all counters?',
+                body: 'This clears all proxy logs and WAF statistics. This cannot be undone.',
+                confirmLabel: 'Reset counters',
+                destructive: true,
+              }))) return;
               const t = toast.loading('Resetting counters...');
               try {
                 await api.post('counters/reset');


### PR DESCRIPTION
**Wave 3 — PR 5 of 6.** One accessible confirm dialog for destructive actions.

Destructive actions were inconsistent and partly **unguarded**: Settings →
Maintenance fired **"Reset Counters" (wipes ALL proxy logs + WAF stats)** and
**"Clear Cache"** immediately on a single click; the Dashboard reset used a native
`window.confirm`.

- New accessible `AlertDialog` (`role="alertdialog"`, focus-trap + Escape + focus
  restore via `useModal`) driven by a promise-based `useConfirm()`:
  `if (!(await confirm({ title, body, destructive }))) return;`.
- Gate Maintenance **Reset Counters** + **Clear Cache** (the one-click-wipe was the
  real gap).
- Replace the Dashboard `window.confirm` with the same styled dialog.

The Logs/Blacklists two-step inline confirms already gate their actions; left as-is.

Verification: `tsc` + lint clean; 136 vitest tests pass incl. a useConfirm test
(opens an alertdialog, resolves true on confirm / false on cancel, action never
fires without confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)