### PR TITLE
release: v3.8.0 — Wave 3 (UX & accessibility)

### DIFF
--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.7.0"
+const AppVersion = "3.8.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.7.0",
+  "version": "3.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump 3.7.0 -> 3.8.0 for Wave 3 (UX & accessibility): reduced-motion (#113), accessible Toggle (#114), modal focus-trap (#115), chart screen-reader alternatives (#116), shared ConfirmDialog (#117), ClientSetup in wizard + empty state (#118). UI-only wave. Tag + release on the merge commit.