### PR TITLE
ci: lint/go-vet gates + SHA-pinned actions + cosign signing (Wave 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           cache-dependency-path: ui/package-lock.json
       - run: npm ci
         working-directory: ui
+      - run: npm run lint
+        working-directory: ui
       - run: npm run build
         working-directory: ui
       - run: npm test
@@ -40,6 +42,8 @@ jobs:
           cache-dependency-path: backend-go/go.sum
       - run: go build -v ./...
         working-directory: backend-go
+      - run: go vet ./...
+        working-directory: backend-go
 
   # ── 3. Go WAF build ───────────────────────────────────────────────────
   build-waf:
@@ -52,6 +56,8 @@ jobs:
           go-version: '1.24'
           cache-dependency-path: waf-go/go.sum
       - run: go build -v ./...
+        working-directory: waf-go
+      - run: go vet ./...
         working-directory: waf-go
 
   # ── 4. Go backend tests ──────────────────────────────────────────────

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,10 +41,10 @@ jobs:
         working-directory: docs
 
       - name: Configure Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs/.vitepress/dist
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # OIDC token for cosign keyless signing
     strategy:
       matrix:
         include:
@@ -39,13 +40,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up QEMU (for ARM64 emulation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -61,7 +62,8 @@ jobs:
           fi
 
       - name: Build and push ${{ matrix.image }}
-        uses: docker/build-push-action@v5
+        id: build
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -76,3 +78,18 @@ jobs:
           # consumers can audit contents and verify the build origin.
           sbom: true
           provenance: mode=max
+
+      # Keyless (OIDC) signature via cosign, so consumers can verify the image
+      # provenance against this repo's identity. Best-effort for now
+      # (continue-on-error) so a signing hiccup never blocks the image publish;
+      # promote to required once verified on a real release tag.
+      - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+      - name: Sign the published image (keyless)
+        if: startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ env.IMAGE_PREFIX }}-${{ matrix.image }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"


### PR DESCRIPTION
**Wave 4 — CI hardening.** From the audit's missing-gates list, non-gating where it could surprise.

- **ESLint gate**: `npm run lint` in build-ui (eslint exits 0 on the 2 pre-existing
  warnings → gates on errors only).
- **`go vet ./...`** added to the backend + waf build jobs.
- **SHA-pin** the floating actions in `multi-arch.yml` (docker/setup-qemu, setup-buildx,
  login, build-push) and `docs.yml` (configure-pages, upload-pages-artifact,
  deploy-pages) → real v3/v4/v5 commit SHAs (fetched from the GitHub API).
- **cosign** keyless (OIDC) signing of each published image in `multi-arch.yml`:
  `id-token: write`, install cosign, `cosign sign --yes <image>@<digest>` **on release
  tags only**, `continue-on-error` so a signing hiccup can't block the publish — promote
  to required after verifying on a real tag.

**CodeQL** is already active via GitHub's **default setup** (go, javascript-typescript,
python, actions) — confirmed `state: configured` — so no codeql workflow file is added
(an advanced-setup file would conflict with the default setup).

All 3 workflow YAMLs validated. cosign/pins in multi-arch/docs execute on tag/docs events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)