### PR TITLE
fix(e2e): repair the test stack + auth so the Playwright suite runs

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -32,7 +32,7 @@ services:
       - CORS_ALLOWED_ORIGINS=http://web:8011,http://localhost:8011
       - DATABASE_PATH=/data/secure_proxy_test.db
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:5000/health"]
+      test: ["CMD", "/server", "-healthcheck"]
       interval: 5s
       timeout: 3s
       retries: 15
@@ -53,7 +53,7 @@ services:
       - BACKEND_URL=http://backend:5000
       - REQUEST_TIMEOUT=120
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:8011/health"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8011/health || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 15
@@ -75,7 +75,7 @@ services:
       - ./tests/mock-lists/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./tests/mock-lists:/usr/share/nginx/html:ro
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:8080/health"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/health || exit 1"]
       interval: 3s
       timeout: 2s
       retries: 10
@@ -99,7 +99,7 @@ services:
       mock-lists:
         condition: service_healthy
     environment:
-      - BASE_URL=http://web:8011
+      - BASE_URL=https://web:8443
       - API_URL=http://backend:5000
       - TEST_USERNAME=${TEST_USERNAME:-testadmin}
       - TEST_PASSWORD=${TEST_PASSWORD:-TestP@ss123!}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
   ],
 
   use: {
-    baseURL: process.env.BASE_URL ?? 'http://localhost:8011',
+    baseURL: process.env.BASE_URL ?? 'https://localhost:8443',
+    // The web serves only HTTPS (HTTP 8011 301-redirects everything except
+    // /health); accept its self-signed cert.
+    ignoreHTTPSErrors: true,
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
     trace: 'on-first-retry',

--- a/tests/e2e/selfhoster.spec.ts
+++ b/tests/e2e/selfhoster.spec.ts
@@ -7,12 +7,12 @@
  *
  * Architecture notes:
  *   - API tests run via Playwright's `request` fixture (no browser overhead)
- *   - UI tests drive real Chromium, inject JWT into sessionStorage via addInitScript
+ *   - UI tests drive real Chromium, inject JWT into localStorage via addInitScript
  *     (Playwright storageState only persists localStorage, so we inject per-test)
  *   - Auth tests deliberately run WITHOUT token injection
  *
  * Environment variables (set in docker-compose.test.yml):
- *   BASE_URL          http://web:8011          (UI + nginx proxy)
+ *   BASE_URL          https://web:8443         (UI + nginx, HTTPS only)
  *   API_URL           http://backend:5000      (direct backend)
  *   TEST_USERNAME     testadmin
  *   TEST_PASSWORD     TestP@ss123!
@@ -46,7 +46,7 @@ async function apiToken(request: APIRequestContext): Promise<string> {
     data: { username: USERNAME, password: PASSWORD },
   });
   expect(res.ok(), `Login failed (${res.status()}): ${await res.text()}`).toBeTruthy();
-  const { token } = (await res.json()) as { token: string };
+  const { access_token: token } = (await res.json()) as { access_token: string };
   return token;
 }
 
@@ -58,17 +58,27 @@ async function apiToken(request: APIRequestContext): Promise<string> {
 async function injectAuth(page: Page, request: APIRequestContext): Promise<void> {
   const token = await apiToken(request);
   await page.addInitScript((t: string) => {
-    sessionStorage.setItem('auth_token', t);
+    localStorage.setItem('auth_token', t);
   }, token);
 }
+
+// Mark the first-run Setup Wizard complete once for the whole run, so
+// authenticated views land on the Dashboard instead of the wizard gate.
+test.beforeAll(async ({ request }) => {
+  const token = await apiToken(request);
+  await request.post('/api/settings', {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { wizard_completed: 'true' },
+  });
+});
 
 // ─── AUTH ─────────────────────────────────────────────────────────────────────
 
 test.describe('Authentication', () => {
   // No token injection — these tests verify the unauthenticated flow
   test.beforeEach(async ({ page }) => {
-    // Ensure sessionStorage is clear (no leftover token from other tests)
-    await page.addInitScript(() => { sessionStorage.clear(); });
+    // Ensure storage is clear (no leftover token from other tests)
+    await page.addInitScript(() => { localStorage.clear(); sessionStorage.clear(); });
   });
 
   test('shows login form when unauthenticated', async ({ page }) => {
@@ -95,7 +105,7 @@ test.describe('Authentication', () => {
     await page.fill('#username', USERNAME);
     await page.fill('#password', PASSWORD);
     await page.click('button[type="submit"]');
-    await expect(page.locator('text=Configure your device')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('h1', { hasText: 'Dashboard' }).first()).toBeVisible({ timeout: 15_000 });
   });
 
   test('submit button shows loading state', async ({ page }) => {
@@ -137,7 +147,7 @@ test.describe('API — health & auth', () => {
       data: { username: USERNAME, password: PASSWORD },
     });
     expect(res.ok()).toBeTruthy();
-    const { token } = (await res.json()) as { token: string };
+    const { access_token: token } = (await res.json()) as { access_token: string };
     expect(typeof token).toBe('string');
     expect(token.split('.').length).toBe(3); // JWT = 3 base64 segments
   });
@@ -397,7 +407,7 @@ test.describe('UI — Dashboard', () => {
 
   test('shows proxy address banner with host and port 3128', async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('text=Configure your device', { timeout: 15_000 });
+    await page.waitForSelector('h1:has-text("Dashboard")', { timeout: 15_000 });
     await expect(page.locator('code').filter({ hasText: '3128' }).first()).toBeVisible();
   });
 
@@ -411,14 +421,14 @@ test.describe('UI — Dashboard', () => {
       });
     });
     await page.goto('/');
-    await page.waitForSelector('text=Configure your device');
+    await page.waitForSelector('h1:has-text("Dashboard")');
     await page.getByRole('button', { name: /copy/i }).first().click();
     await expect(page.getByText('Copied!')).toBeVisible({ timeout: 5_000 });
   });
 
   test('shows stats cards (Total Requests, Blocked, Direct IP, Security)', async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('text=Configure your device');
+    await page.waitForSelector('h1:has-text("Dashboard")');
     for (const label of ['Total Requests', 'Blocked Threats', 'Direct IP Blocks', 'Security Score']) {
       await expect(page.getByText(label)).toBeVisible();
     }
@@ -426,7 +436,7 @@ test.describe('UI — Dashboard', () => {
 
   test('activity chart is rendered', async ({ page }) => {
     await page.goto('/');
-    await page.waitForSelector('text=Configure your device');
+    await page.waitForSelector('h1:has-text("Dashboard")');
     await expect(page.locator('svg').first()).toBeVisible();
   });
 });
@@ -704,7 +714,7 @@ test.describe('Full onboarding flow', () => {
     await page.fill('#username', USERNAME);
     await page.fill('#password', PASSWORD);
     await page.click('button[type="submit"]');
-    await expect(page.locator('text=Configure your device')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('h1', { hasText: 'Dashboard' }).first()).toBeVisible({ timeout: 15_000 });
 
     // 2. Note proxy address
     const proxyAddr = await page.locator('code').filter({ hasText: '3128' }).first().textContent();


### PR DESCRIPTION
Follow-up to #123 (wiring Playwright into CI), which surfaced that the orphaned
suite **never actually ran**. The linked CI failure was `container
secure-proxy-manager-backend-1 is unhealthy` — a setup failure, not a test failure.

Fixed the systemic blockers (all verified by running the stack locally):

1. **Healthchecks used `curl`**, which is in **none** of the images (backend alpine
   = docker-cli only; web/mock-lists = nginx-alpine with `wget`). The backend was
   never healthy → the test-runner's `depends_on` never fired → the job died at
   setup. Backend → production `/server -healthcheck` built-in; web/mock-lists → `wget`.
2. **Web is HTTPS-only** (HTTP :8011 301-redirects everything but `/health`) → every
   request through `http://web:8011` was 301'd. Point the suite at `https://web:8443`
   + `ignoreHTTPSErrors`.
3. **Auth drift**: login returns `access_token` (suite read `token`); the app stores
   the JWT in `localStorage` (suite used `sessionStorage`). Both fixed → the whole
   API layer + token-injected UI tests go green.
4. **Fresh DB shows the Setup Wizard**, not the Dashboard → seed `wizard_completed=true`
   once; replace the stale `text=Configure your device` marker (gone) with the
   `Dashboard` heading.

**Result**: the suite now boots, runs, and the API + auth + login + dashboard layers
pass. A long tail of individual UI-element selector drift remains (copy button is
now icon-only, some stat-card labels / nav / domain-tab controls changed) — a
focused follow-up; the `e2e-ui` job stays **non-gating** until fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)