### PR TITLE
release: v3.8.1

### DIFF
--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.8.0"
+const AppVersion = "3.8.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.8.0",
+  "version": "3.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch bump 3.8.0 → 3.8.1, tagging the accumulated main state since v3.8.0.

Since v3.8.0:
- **#120** removed the dead `Config.ProxyPort` field (the only runtime delta — behaviourally inert) + deleted the `validate_fixes.sh` fossil
- **#121/#122** docs rewritten/reconciled for the Go stack (DEPLOYMENT, BENCHMARKS, SECURITY)
- **#123/#124** CI: Playwright e2e wired in, ESLint + go vet gates, SHA-pinned actions, cosign signing
- **#126/#127** repaired the Playwright e2e suite — now **59/59 green** in CI

No user-facing behaviour change. Bumps `version.go` + `ui/package.json`; tag + release on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)