### PR TITLE
Bump vite to 8.0.5 (high)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -44,7 +44,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1",
+    "vite": "^8.0.5",
     "vitest": "^4.1.2"
   },
   "overrides": {


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `vite` `8.0.1` → `8.0.5`
**Manifest:** `ui/package.json`
**Severity:** high
**Advisory:** Vite Vulnerable to Arbitrary File Read via Vite Dev Server WebSocket CVE-2026-39363, CVE-2026-39364, CVE-2026-39365

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `3f5f40259b537487` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"3f5f40259b537487","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->