### PR TITLE
chore(release): v3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.0] - 2026-06-15
+
+### Added
+
+- **Egress destination allowlist (default-deny mode).** Opt-in via a new
+  "Default-deny egress" toggle in Settings: a client behind the proxy may then
+  reach only the destinations on the new **Egress Allowlist** (CIDR/IP or
+  domain); everything else is denied. This turns the forward proxy from
+  default-allow-destination into default-deny-destination — the basis for a
+  sovereign / data-residency egress. Includes a managed allowlist page, a REST
+  API (`/api/egress-allowlist`), and Squid `dst`/`dstdomain` enforcement driven
+  by the existing list + toggle plumbing. Off by default.
+
+### Security
+
+- Bump Go 1.24 → 1.26, clearing newly-disclosed Go standard-library advisories
+  (net/http, net, crypto/x509, net/textproto) that have no 1.24 patch.
+- Bump esbuild to 0.28.1 (devDependency), clearing a HIGH npm advisory
+  (GHSA-gv7w-rqvm-qjhr; affects the dev server only, not the production build).
+
 ## [3.5.0] - 2026-06-04
 
 ### Added

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.8.1"
+const AppVersion = "3.9.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.8.1",
+  "version": "3.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v3.9.0

MINOR bump (new feature, per the project's stated semver):

- `backend-go/internal/config/version.go` and `ui/package.json` -> 3.9.0
- CHANGELOG entry for the **egress destination allowlist (default-deny mode)**
  feature (#132) and the **Go 1.26 / esbuild 0.28.1** security bumps (#133).

No code changes beyond the version strings + changelog. Tag `v3.9.0` + GitHub
Release to follow on your OK.

Generated with [Claude Code](https://claude.com/claude-code)
