### PR TITLE
docs: document the default-deny egress allowlist (v3.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ notifications) is managed from the UI and stored in the database, not in `.env`.
 - DNS sinkholing of blacklisted domains via dnsmasq, so blocked lookups never
   reach the proxy at all.
 - Direct-IP-access blocking and a method whitelist in Squid.
+- Optional default-deny egress (off by default): instead of the deny-list
+  blacklists, allow outbound traffic only to an explicit CIDR/domain allowlist
+  and refuse everything else. Toggled in Settings; destinations managed on the
+  Egress Allowlist page.
 
 **WAF**
 - 175 regex rules across 23 toggleable categories (SQLi, XSS, traversal, C2,
@@ -135,6 +139,10 @@ precedence.
 **Inspect HTTPS.** Settings > enable SSL inspection, download the generated CA,
 and install it as trusted on your clients. Without this, HTTPS requests are only
 filtered by host/IP and DNS, not by WAF body rules.
+
+**Lock egress to an allowlist.** Settings > enable default-deny egress, then add
+the approved IPs/CIDRs and domains on the Egress Allowlist page. Local clients
+can then reach only those destinations; everything else is refused.
 
 **Import a blocklist.** Blacklists > Import supports popular public lists by URL
 or pasted content. Imports are size-bounded and fetched with an SSRF-safe client
@@ -198,7 +206,7 @@ ESLint, Go vet/test, and the UI build is at `scripts/pre-commit-validate.sh`.
 
 ## API
 
-The backend exposes a REST API (72 routes) used by the UI. A machine-readable
+The backend exposes a REST API (77 routes) used by the UI. A machine-readable
 listing is available at `GET /api/docs`. Authenticate with HTTP Basic auth, or
 exchange credentials at `POST /api/auth/login` for a JWT and send it as a Bearer
 token.

--- a/docs/api/blacklists.md
+++ b/docs/api/blacklists.md
@@ -303,3 +303,82 @@ POST /api/domain-whitelist
 ```
 DELETE /api/domain-whitelist/{id}
 ```
+
+---
+
+## Egress allowlist {#egress-allowlist}
+
+The egress allowlist is the deny-by-default complement to the blacklists. It is consulted only when default-deny egress is enabled (the `egress_default_deny` setting, default `false`). While that setting is off — the default — behaviour is unchanged: clients may reach any destination not on a blacklist, and this allowlist has no effect. When it is on, the proxy denies all outbound egress from local clients except destinations on this allowlist; everything else is refused with a Squid 403.
+
+The `egress_default_deny` toggle is set via the bulk settings endpoint (`POST /api/settings`, flat `{name: value}` body), not through this group.
+
+Each entry is either an IP/CIDR (matched by Squid `dst`) or a domain (matched by Squid `dstdomain`). The type is auto-classified on add: a value parseable as an IP or CIDR is stored as type `cidr`, otherwise it is treated as a `domain`.
+
+### List entries
+
+```
+GET /api/egress-allowlist
+```
+
+```json
+{
+  "status": "success",
+  "data": [
+    {
+      "id": 1,
+      "entry": "acme-v02.api.example",
+      "type": "domain",
+      "description": "ACME server",
+      "added_date": "2026-03-01T12:00:00"
+    }
+  ]
+}
+```
+
+### Add entry
+
+```
+POST /api/egress-allowlist
+```
+
+```json
+{
+  "entry": "203.0.113.0/24",
+  "description": "optional description"
+}
+```
+
+`entry` accepts an IP, a CIDR range, or a domain; the type is auto-classified to `cidr` or `domain`.
+
+**Success:**
+
+```json
+{
+  "status": "success",
+  "message": "Entry added to egress allowlist"
+}
+```
+
+A 400 is returned with `"entry must be an IP, CIDR, or domain"` when `entry` is empty, whitespace, or otherwise invalid, and with `"entry already in allowlist"` on a duplicate.
+
+### Delete entry
+
+```
+DELETE /api/egress-allowlist/{id}
+```
+
+### Bulk delete
+
+```
+POST /api/egress-allowlist/bulk-delete
+```
+
+```json
+{ "ids": [1, 2, 3] }
+```
+
+### Clear all
+
+```
+DELETE /api/egress-allowlist/clear-all
+```

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -44,6 +44,18 @@ Every endpoint accepts either HTTP Basic or JWT bearer authentication unless not
 | `POST`   | `/api/domain-whitelist` | Add a domain whitelist entry |
 | `DELETE` | `/api/domain-whitelist/{id}` | Delete a domain whitelist entry |
 
+## Egress allowlist
+
+Optional default-deny outbound egress. Off by default (the `egress_default_deny` setting is `false`); when off, behaviour is unchanged and clients may reach any destination not on a blacklist. When the setting is on, local clients may only reach destinations on this allowlist. The toggle itself is set through the bulk settings endpoint (`POST /api/settings`), not through this group. Each entry is auto-classified as a CIDR or a domain on add. See [Blacklists and Whitelists](../guide/blacklists.md) for full details.
+
+| Method | Path | Description |
+|---|---|---|
+| `GET`    | `/api/egress-allowlist` | List egress allowlist entries |
+| `POST`   | `/api/egress-allowlist` | Add an entry (`{"entry": "<ip\|cidr\|domain>", "description": "<optional>"}`) |
+| `DELETE` | `/api/egress-allowlist/{id}` | Delete an egress allowlist entry |
+| `POST`   | `/api/egress-allowlist/bulk-delete` | Delete multiple egress allowlist entries |
+| `DELETE` | `/api/egress-allowlist/clear-all` | Remove all egress allowlist entries |
+
 ## Logs and analytics
 
 | Method | Path | Description |

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -58,6 +58,24 @@ All updates are applied in a single transaction. The same name and value validat
 
 ---
 
+## Default-deny egress
+
+```
+POST /api/settings
+```
+
+```json
+{ "egress_default_deny": "true" }
+```
+
+`egress_default_deny` is a boolean setting (default `"false"`) toggled like any other value through the bulk or single-setting endpoints. It is also exposed as the "Default-deny egress" toggle on the Settings page, next to SSL inspection.
+
+When `"false"` (the default) behaviour is unchanged: local clients may reach any destination that is not on a blacklist. When `"true"` the proxy denies all outbound egress from local clients except destinations on an explicit allowlist; everything else is refused with a Squid 403.
+
+The allowlist destinations themselves are not setting values. They are managed through the egress-allowlist endpoints (`/api/egress-allowlist`), where each entry is either an IP/CIDR or a domain. See the egress allowlist API for details.
+
+---
+
 ## Health
 
 ```

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -63,14 +63,17 @@ The `frontend` network connects `web` to `backend`. The `proxy-internal` network
 - `log_tailer` worker reads `/var/log/squid/access.log` and inserts parsed entries into the `proxy_logs` table.
 - `blacklist_refresh` worker re-imports configured public lists at the interval defined by the `auto_refresh_hours` setting.
 - Applies blacklist and whitelist changes by writing files under `/config/` and signalling the proxy or DNS service to reload.
+- When default-deny egress is enabled, exports the `dst_allowlist` table to `/config/dst_allow_ip.txt` (CIDR entries) and `/config/dst_allow_domain.txt` (domain entries), both written atomically, and writes the flag file `/config/egress_default_deny` to reflect the toggle.
 - WebSocket endpoint at `/api/ws/logs` broadcasts new log entries to connected UI clients.
 
 ### `proxy` — Squid
 
 - Forward proxy on port `3128`.
 - `proxy/startup.sh` generates `squid.conf` from a base template plus optional extras from `/config/custom_squid_extra.conf`, validates with `squid -k parse`, then initialises the cache with `squid -z`.
+- `blacklist_watchdog.py` polls the `/config` list files by mtime (roughly every two seconds) — including `dst_allow_ip.txt` and `dst_allow_domain.txt` — and runs `squid -k reconfigure` when one changes, so backend writes to the allowlist take effect without a restart.
 - ICAP integration forwards REQMOD and RESPMOD adaptations to the WAF.
 - Direct-IP access is blocked by ACL rules; whitelisted destination IPs in `ip_whitelist.txt` bypass that block.
+- When `/config/egress_default_deny` is present, `startup.sh` injects two ACLs — `acl egress_dst_allow_ip dst "<path>/dst_allow_ip.txt"` and `acl egress_dst_allow_dom dstdomain "<path>/dst_allow_domain.txt"` — and, immediately before the first `http_access allow localnet`, the rule `http_access deny localnet !egress_dst_allow_ip !egress_dst_allow_dom`. Local clients are then allowed only when the destination matches the IP allowlist or the domain allowlist; every other destination is refused. The toggle is off by default, so this mode is opt-in and the proxy otherwise reaches any destination not on a blacklist.
 - SSL bump uses the CA certificate at `/config/ssl_cert.pem` (auto-generated on first start if absent).
 - The container `iptables` rules redirect transparent intercepted traffic on ports 80 and 443 to 3128 inside the container.
 
@@ -101,7 +104,7 @@ The `frontend` network connects `web` to `backend`. The `proxy-internal` network
 
 1. The client sends an HTTP or HTTPS request to Squid on port `3128`.
 2. Squid issues an ICAP `REQMOD` to the WAF. The WAF inspects the URL, headers, and (for write methods) the request body; if the anomaly score exceeds the threshold it returns an HTTP 403 ICAP response and notifies the backend.
-3. If the WAF allows the request, Squid evaluates its ACLs: IP blacklist (source), domain blacklist (destination), direct-IP rule, and the IP whitelist that bypasses it.
+3. If the WAF allows the request, Squid evaluates its ACLs: IP blacklist (source), domain blacklist (destination), direct-IP rule, and the IP whitelist that bypasses it. When default-deny egress is enabled, a local client is allowed only if the destination is on the IP or domain allowlist; any other destination is refused with a 403.
 4. If Squid allows the request, it is forwarded to the destination. For HTTPS with SSL bump enabled, the connection is decrypted, inspected, and re-encrypted.
 5. Squid writes an entry to `/var/log/squid/access.log`.
 6. The backend `log_tailer` reads the new entry, parses it, inserts a row into `proxy_logs`, and broadcasts it to subscribed WebSocket clients.
@@ -110,7 +113,7 @@ The `frontend` network connects `web` to `backend`. The `proxy-internal` network
 
 | Volume | Purpose |
 |---|---|
-| `./config` | Shared configuration: blacklist/whitelist text files, SSL certificate, custom Squid extras, dynamic settings |
+| `./config` | Shared configuration: blacklist/whitelist text files, egress allowlist files (`dst_allow_ip.txt`, `dst_allow_domain.txt`) and the `egress_default_deny` flag, SSL certificate, custom Squid extras, dynamic settings |
 | `./data` | SQLite database |
 | `./logs` | Mounted as `/var/log/squid` inside the proxy container |
 | `squid-cache` (named) | Squid disk cache |

--- a/docs/guide/blacklists.md
+++ b/docs/guide/blacklists.md
@@ -46,6 +46,56 @@ Whitelisted domains are removed from the dnsmasq blocklist, so they resolve norm
 
 Manage via **Web UI → Blacklists → Domain Whitelist** or the [API](/api/blacklists#domain-whitelist).
 
+## Destination allowlist (default-deny egress)
+
+The blacklists above are deny-lists: clients may reach any destination that is not explicitly blocked. The destination allowlist inverts that for outbound egress. When enabled, the proxy denies all egress from local clients **except** destinations on the allowlist, and refuses everything else with a Squid `403`.
+
+This is the deny-by-default complement to the domain and IP blacklists and the direct-IP block rule. Use it for a strict "allow-only-these-destinations" outbound policy — for example, to let an app behind the proxy reach only an approved CA/ACME server, package mirror, or internal API and nothing else.
+
+::: warning
+Default-deny egress is **off by default**. While it is off, behaviour is unchanged: clients reach any destination that is not blacklisted. Turning it on with an empty allowlist blocks all outbound egress from local clients.
+:::
+
+### Enable default-deny egress
+
+Toggle **Default-deny egress** on the **Settings** page (next to SSL inspection), or set it through the bulk settings API:
+
+```bash
+curl -X POST https://localhost:8443/api/settings \
+  -H "Content-Type: application/json" -H "$AUTH" \
+  -d '{"egress_default_deny": true}'
+```
+
+The setting is `egress_default_deny` and defaults to `false`.
+
+### Manage allowed destinations
+
+Add destinations on the **Egress Allowlist** page (add, delete, search, paginate), or via the API. Each entry is one of:
+
+- IP or CIDR: `203.0.113.10`, `198.51.100.0/24` — matched on the destination IP.
+- Domain: `acme-v02.api.letsencrypt.org` — matched on the destination domain.
+
+The type is classified automatically on add: a value that parses as an IP or CIDR is stored as `cidr`, otherwise it is treated as a `domain`. A local client is allowed only if the destination matches the IP allowlist **or** the domain allowlist.
+
+```bash
+# Add a destination (auto-classified as cidr or domain)
+curl -X POST https://localhost:8443/api/egress-allowlist \
+  -H "Content-Type: application/json" -H "$AUTH" \
+  -d '{"entry": "acme-v02.api.letsencrypt.org", "description": "ACME"}'
+
+# List entries
+curl https://localhost:8443/api/egress-allowlist -H "$AUTH"
+
+# Delete one entry by ID
+curl -X DELETE https://localhost:8443/api/egress-allowlist/42 -H "$AUTH"
+```
+
+`POST /api/egress-allowlist/bulk-delete` removes entries by a list of IDs, and `DELETE /api/egress-allowlist/clear-all` removes them all. The `egress_default_deny` toggle is set through the bulk settings endpoint, not this group.
+
+::: tip
+Whitelists and blacklists still apply when default-deny egress is on. A destination must be on the allowlist **and** must not be blacklisted to be reachable.
+:::
+
 ## Importing blocklists
 
 ### Curated public lists (one click)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -93,6 +93,17 @@ Custom directives are appended after the base configuration; later directives ov
 
 These can be overridden through the **Settings** page of the web UI, which writes the values to `/config/squid_settings.env`.
 
+## Default-deny egress (optional)
+
+By default the proxy is a deny-list gateway: clients may reach any destination that is not blacklisted. You can optionally switch it into a default-deny egress gateway, where local clients can reach **only** the destinations on an explicit allowlist and everything else is refused with a Squid 403.
+
+This mode is off by default and is configured entirely from the web UI and API, not via `.env`:
+
+- Enable it with the **Default-deny egress** toggle on the **Settings** page (next to SSL inspection). It maps to the `egress_default_deny` setting, which defaults to `false`.
+- Manage allowed destinations on the **Egress Allowlist** page (add, delete, search, paginate). Each entry is either an IP/CIDR or a domain; the type is auto-classified when you add it. A client is allowed only if the destination matches the IP allowlist or the domain allowlist.
+
+When the toggle is off, behaviour is unchanged and no destinations are blocked by this feature. Use default-deny egress when you need a strict "allow only these destinations" outbound policy — for example, letting an application reach only an approved ACME server, package mirror, or internal API.
+
 ## WAF custom rules
 
 Create `/config/waf_custom_rules.txt` with one regex per line. Lines starting with `#` are ignored. Each line is rejected if longer than 512 characters or if it contains a NUL byte. Restart the `waf` service to reload:

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -8,6 +8,7 @@ It is intended for homelab operators and small networks that need a manageable, 
 
 - **Forward proxy.** HTTP and HTTPS (with optional SSL bump) traffic filtering through Squid.
 - **Blacklists.** Domain blocking with exact match or wildcard subdomain (`*.example.com`); IP blocking with single addresses or CIDR ranges.
+- **Egress allowlist.** Optional default-deny outbound egress that turns the proxy into a strict egress gateway. When enabled, local clients may reach only the destinations on an explicit allowlist of IP/CIDR and domain entries; everything else is refused. Off by default — when off, behaviour is unchanged and clients may reach any destination not on a blacklist.
 - **IP whitelist.** Trusted destination IPs that bypass the direct-IP block rule.
 - **Domain whitelist.** Domains excluded from the dnsmasq DNS sinkhole.
 - **WAF.** A Go ICAP server that inspects request payloads with 175 regex rules across 23 categories and 7 behavioural heuristics (entropy, beaconing, PII, sharding, ghosting, morphing, sequence). Limited response inspection (reflected XSS, secret leak, PII) is also performed.

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -56,6 +56,33 @@ A wildcard (`*`) is stripped at load time and is not accepted.
 
 Squid is configured to reject requests to raw IP addresses by default, preventing clients from bypassing the domain blacklist by addressing destinations directly. Add trusted destinations to the **IP whitelist** (`/config/ip_whitelist.txt`, also editable via the UI) to allow specific exceptions; whitelisted IPs are evaluated before the deny rule.
 
+## Default-deny egress
+
+The domain and IP blacklists and direct-IP blocking are deny-lists: a client may reach any destination that is not explicitly forbidden. Default-deny egress inverts this for environments that require a strict, allow-only outbound policy. When enabled, the proxy refuses all outbound egress from local clients except destinations on an explicit allowlist; every other destination is denied with an HTTP 403. Restricting outbound traffic to an approved set of endpoints reduces the exfiltration and lateral-movement surface and supports sovereign or strictly scoped egress policies — for example, allowing an application behind the proxy to reach only a CA/ACME server, a package mirror, and an internal API, and nothing else.
+
+This mode is **off by default**. With the `egress_default_deny` setting set to `false` (the default), behaviour is unchanged and clients may reach any destination not on a blacklist. Enabling it only restricts egress; it does not affect any other rule.
+
+To enable it:
+
+1. Turn on the **Default-deny egress** toggle on the **Settings** page (shown next to SSL inspection). This flips the `egress_default_deny` setting, which can also be set through the bulk settings API (`POST /api/settings`).
+2. Populate the **Egress Allowlist** page with the destinations clients are permitted to reach. Each entry is either an IP/CIDR or a domain; the type is auto-classified on add (a value that parses as an IP or CIDR is stored as `cidr`, otherwise as `domain`). Entries can be added, deleted, searched, and paginated from the UI or managed through the API.
+
+A local client is allowed only if the destination matches the IP allowlist **or** the domain allowlist; anything else is refused.
+
+### Egress allowlist API
+
+The allowlist endpoints use the same authentication as the rest of the API (HTTP Basic or JWT bearer):
+
+| Method   | Path                              | Description |
+| -------- | --------------------------------- | ----------- |
+| `GET`    | `/api/egress-allowlist`           | List entries (paginated). |
+| `POST`   | `/api/egress-allowlist`           | Add one entry. Body `{"entry": "<ip\|cidr\|domain>", "description": "<optional>"}`. The type is auto-classified. Returns 400 (`entry must be an IP, CIDR, or domain`) for empty or invalid input, 400 (`entry already in allowlist`) for a duplicate, and 200 (`{"status":"success","message":"Entry added to egress allowlist"}`) on success. |
+| `DELETE` | `/api/egress-allowlist/{id}`      | Remove one entry by ID. |
+| `POST`   | `/api/egress-allowlist/bulk-delete` | Remove entries by a list of IDs. |
+| `DELETE` | `/api/egress-allowlist/clear-all` | Remove all entries. |
+
+The `egress_default_deny` toggle itself is set through the bulk settings endpoint, not through this group.
+
 ## Database export redaction
 
 `GET /api/database/export` returns a full JSON dump of the database. Any column literally named `password`, `secret`, or `token` (across every exported table) is replaced with the string `***REDACTED***` before serialisation. Sensitive settings stored under those column names are therefore never present in the export.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,8 @@ hero:
 features:
   - title: Traffic filtering
     details: Domain and IP blocking with CIDR and wildcard subdomain support. One-click import of curated public blocklists. Geo-based IP blocking by country code.
+  - title: Egress allowlist
+    details: Optional default-deny outbound egress. Turn SPM into a strict egress gateway where local clients reach only an explicit allowlist of IP/CIDR and domain destinations. Off by default; when off, behaviour is unchanged.
   - title: IP whitelist
     details: Whitelist trusted destination IPs to bypass the direct-IP block rule. Useful for LAN devices accessed by IP address.
   - title: ICAP WAF


### PR DESCRIPTION
Documents the egress destination allowlist feature shipped in v3.9.0 (#132), so the README and the VitePress site reflect the new capability and API surface.

## What changed
- **README**: a Filtering bullet for the optional default-deny egress, a "Lock egress to an allowlist" how-to, and the API route count corrected `72` -> `77`.
- **docs/index.md, guide/introduction.md**: capability entries framing SPM as a strict egress gateway.
- **api/blacklists.md, api/reference.md**: the `/api/egress-allowlist` endpoint group (list, add, delete, bulk-delete, clear-all) with request/response shapes and cidr-vs-domain auto-classification.
- **api/settings.md**: the `egress_default_deny` boolean setting.
- **guide/blacklists.md, guide/security.md, guide/configuration.md**: how to enable default-deny egress and manage allowed destinations, framed as the deny-by-default complement to the blacklists.
- **guide/architecture.md**: the `dst_allowlist` DB -> `/config/dst_allow_*.txt` -> watchdog -> `squid -k reconfigure` enforcement pipeline and the injected Squid ACLs.

## Notes
- Off by default and non-breaking throughout; every page states clients still reach any non-blacklisted destination when the mode is off.
- All facts verified against the backend source (route names, setting name, response shapes, route count).
- `vitepress build` passes with no dead links. No emoji introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)