### PR TITLE
feat(phase2a): WAF detection hardening — comment/unicode evasion, oversize & uninspectable signals

### DIFF
--- a/waf-go/fase2a_test.go
+++ b/waf-go/fase2a_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"io"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/go-icap/icap"
+)
+
+func nopRC(s string) io.ReadCloser { return io.NopCloser(strings.NewReader(s)) }
+
+func mustCompileCI(p string) *regexp.Regexp { return regexp.MustCompile("(?i)" + p) }
+
+// Comment-based and homoglyph evasions must be normalized so the existing
+// signature rules still fire. We feed input through the same normalize → match
+// path the handler uses.
+func TestNormalizationDefeatsEvasion(t *testing.T) {
+	cases := []struct {
+		name  string
+		raw   string
+		block bool
+	}{
+		{"plain UNION SELECT", "a=1 UNION SELECT password FROM users", true},
+		{"inline-comment SQLi", "a=1 UNION/**/SELECT password FROM users", true},
+		{"multi-comment SQLi", "a=1 UN/**/ION/**/SELECT x", false}, // UN ION is not the UNION keyword — must NOT false-positive
+		{"plain script tag", "<script>alert(1)</script>", true},
+		{"html-comment split script", "<scr<!-- -->ipt>alert(1)", true},
+		{"fullwidth script tag", "＜script＞alert(1)", true}, // ＜script＞ via NFKC
+		{"benign query", "q=hello+world&lang=en", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			norm := normalizeInput(c.raw)
+			_, score := matchRulesScored(norm)
+			blocked := score >= blockThreshold
+			if blocked != c.block {
+				t.Errorf("raw=%q normalized=%q score=%d blocked=%v want %v", c.raw, norm, score, blocked, c.block)
+			}
+		})
+	}
+}
+
+func TestIsCompressedEncoding(t *testing.T) {
+	for _, e := range []string{"gzip", "br", "deflate", "compress", "zstd", "GZIP", " gzip "} {
+		if !isCompressedEncoding(e) {
+			t.Errorf("isCompressedEncoding(%q) = false, want true", e)
+		}
+	}
+	for _, e := range []string{"", "identity", "  "} {
+		if isCompressedEncoding(e) {
+			t.Errorf("isCompressedEncoding(%q) = true, want false", e)
+		}
+	}
+}
+
+// A request body larger than the inspection limit must be flagged (counter +
+// corroborating signal), not silently allowed.
+func TestOversizeBodyFlagged(t *testing.T) {
+	before := bodyTruncatedCount.Load()
+	big := strings.Repeat("A", maxBodyInspectSize+1024) // benign padding, over the limit
+	req := &icap.Request{
+		Request: httptest.NewRequest("POST", "http://example.com/upload", strings.NewReader(big)),
+	}
+	req.Request.Header.Set("Content-Type", "text/plain")
+	w := &mockResponseWriter{}
+	handleReqmod(w, req)
+
+	if got := bodyTruncatedCount.Load(); got != before+1 {
+		t.Errorf("bodyTruncatedCount = %d, want %d", got, before+1)
+	}
+	// Benign padding + the oversize signal alone must NOT block (signal < threshold).
+	if w.code == 200 {
+		t.Error("benign oversize body should not block on the oversize signal alone")
+	}
+}
+
+// A compressed text response is uninspectable; the WAF must count it and pass
+// the response through (204) rather than scanning compressed bytes.
+func TestRespmodCompressedIsUninspectable(t *testing.T) {
+	before := respmodUninspectable.Load()
+	resp := httptest.NewRecorder().Result()
+	resp.Header.Set("Content-Type", "text/html")
+	resp.Header.Set("Content-Encoding", "gzip")
+	resp.Body = nopRC("\x1f\x8b\x08 compressed bytes here")
+	req := &icap.Request{Response: resp}
+	w := &mockResponseWriter{}
+	handleRespmod(w, req)
+
+	if w.code != 204 {
+		t.Errorf("expected 204 passthrough, got %d", w.code)
+	}
+	if got := respmodUninspectable.Load(); got != before+1 {
+		t.Errorf("respmodUninspectable = %d, want %d", got, before+1)
+	}
+}
+
+func TestOverlyBroadRule(t *testing.T) {
+	broad := []string{".*", ".+", "", "a?", "(?i).*", "[\\s\\S]*", ".{0,}"}
+	ok := []string{"union\\s+select", "<script", "etc/passwd", "\\.\\./"}
+	for _, p := range broad {
+		re := mustCompileCI(p)
+		if reason := overlyBroadRule(re); reason == "" {
+			t.Errorf("overlyBroadRule(%q) accepted a catch-all pattern", p)
+		}
+	}
+	for _, p := range ok {
+		re := mustCompileCI(p)
+		if reason := overlyBroadRule(re); reason != "" {
+			t.Errorf("overlyBroadRule(%q) rejected a specific pattern: %s", p, reason)
+		}
+	}
+}

--- a/waf-go/go.mod
+++ b/waf-go/go.mod
@@ -5,4 +5,5 @@ go 1.26
 require (
 	github.com/go-icap/icap v0.0.0-20151011115316-ca4fad4ebb28
 	golang.org/x/net v0.56.0
+	golang.org/x/text v0.38.0
 )

--- a/waf-go/go.sum
+++ b/waf-go/go.sum
@@ -2,3 +2,5 @@ github.com/go-icap/icap v0.0.0-20151011115316-ca4fad4ebb28 h1:A5Ks5k2Y1Y3/ibkMrB
 github.com/go-icap/icap v0.0.0-20151011115316-ca4fad4ebb28/go.mod h1:CtySfVdYEiotF1PcVuY0qvLnk02XbSatTR1WJfnIjSk=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=

--- a/waf-go/main.go
+++ b/waf-go/main.go
@@ -47,6 +47,17 @@ var (
 	notifyChan    = make(chan map[string]interface{}, 64)
 	notifyDropped atomic.Int64
 
+	// bodyTruncatedCount counts requests whose body exceeded maxBodyInspectSize,
+	// so only a 1 MB prefix was scanned. Surfaced via /metrics so the coverage
+	// gap (payload hidden behind >1 MB of padding) is observable, not silent.
+	bodyTruncatedCount atomic.Int64
+
+	// respmodUninspectable counts text responses the WAF could NOT actually scan
+	// because the body was compressed (Content-Encoding gzip/br/deflate) — the
+	// regex rules would only see compressed bytes. Surfaced so operators know
+	// response-side coverage has a hole rather than assuming everything was clean.
+	respmodUninspectable atomic.Int64
+
 	// Reusable HTTP client for backend notifications (avoid alloc per call)
 	notifyClient = &http.Client{Timeout: 3 * time.Second, Transport: &http.Transport{
 		MaxIdleConns:        10,
@@ -97,6 +108,28 @@ func cachedAnalyzeDGA(host string) DGAResult {
 
 // ── Custom rules loader ─────────────────────────────────────────────────────
 
+// overlyBroadRule reports a reason string if a compiled custom rule is
+// dangerously broad — it matches the empty string, or matches every entry in a
+// small benign corpus — which would make it fire on essentially all traffic.
+// Returns "" when the rule is acceptably specific.
+func overlyBroadRule(re *regexp.Regexp) string {
+	if re.MatchString("") {
+		return "matches the empty string (would match everything)"
+	}
+	benign := []string{
+		"https://example.com/index.html?lang=en",
+		`{"user":"alice","action":"view","id":42}`,
+		"GET /assets/app.css HTTP/1.1",
+		"the quick brown fox jumps over the lazy dog",
+	}
+	for _, b := range benign {
+		if !re.MatchString(b) {
+			return "" // distinguishes at least one benign input → specific enough
+		}
+	}
+	return "matches all benign sample inputs (too broad)"
+}
+
 func loadCustomRules() {
 	content, err := os.ReadFile("/config/waf_custom_rules.txt")
 	if err != nil {
@@ -121,6 +154,10 @@ func loadCustomRules() {
 			compiled, err := regexp.Compile("(?i)" + line)
 			if err != nil {
 				log.Printf("Error compiling custom rule %s: %v\n", line, err)
+			} else if reason := overlyBroadRule(compiled); reason != "" {
+				// A rule that matches everything (".*", "", "a?", …) would score 7
+				// on every request → mass false-positive blocks. Reject at load.
+				log.Printf("Custom rule %d skipped: %s (pattern %q)\n", i+1, reason, line)
 			} else {
 				customRules = append(customRules, Rule{
 					ID:       fmt.Sprintf("CUSTOM-%03d", i+1),
@@ -377,14 +414,30 @@ func handleReqmod(w icap.ResponseWriter, req *icap.Request) {
 	if score < blockThreshold && req.Request.Body != nil {
 		ct := req.Request.Header.Get("Content-Type")
 		if shouldInspectBody(ct) {
-			bodyBytes, readErr := io.ReadAll(io.LimitReader(req.Request.Body, maxBodyInspectSize))
+			// Read one byte past the inspection limit so we can tell whether the
+			// body was truncated (i.e. a payload may be hiding past the limit).
+			bodyBytes, readErr := io.ReadAll(io.LimitReader(req.Request.Body, maxBodyInspectSize+1))
 			if readErr == nil && len(bodyBytes) > 0 {
+				truncated := len(bodyBytes) > maxBodyInspectSize
+				if truncated {
+					bodyBytes = bodyBytes[:maxBodyInspectSize]
+				}
 				bodyStr = normalizeInput(string(bodyBytes))
 				bodySize = len(bodyBytes)
 				req.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 				bodyMatches, bodyScore := matchRulesScored(bodyStr)
 				matches = append(matches, bodyMatches...)
 				score += bodyScore
+
+				// An over-limit body is a coverage gap, not a clean allow. Add a
+				// corroborating signal (below blockThreshold, so it can't block on
+				// its own — pairs with any other rule/heuristic hit) and count it.
+				if truncated {
+					bodyTruncatedCount.Add(1)
+					const oversizeBodyScore = 4
+					matches = append(matches, MatchResult{RuleID: "WAF-BODY-OVERSIZE", Category: "BODY_OVERSIZE", Score: oversizeBodyScore})
+					score += oversizeBodyScore
+				}
 			}
 		}
 	}
@@ -606,6 +659,15 @@ func handleRespmod(w icap.ResponseWriter, req *icap.Request) {
 			sendBlockResponse(w, "DANGEROUS_CONTENT_TYPE", 10)
 			return
 		}
+	}
+
+	// Compressed text bodies are uninspectable by the regex rules (they'd match
+	// against compressed bytes). Flag the coverage gap rather than silently
+	// returning a clean verdict. Decompression is deferred to a later phase.
+	if req.Response.Body != nil && isTextContent(contentType) && isCompressedEncoding(req.Response.Header.Get("Content-Encoding")) {
+		respmodUninspectable.Add(1)
+		w.WriteHeader(204, nil, false)
+		return
 	}
 
 	// Inspect text response bodies for reflected XSS and secret leaks
@@ -908,10 +970,18 @@ func (h *MgmtHandlers) MetricsHandler(w http.ResponseWriter, r *http.Request) {
 			"waf_trafficlog_dropped_total %d\n"+
 			"# HELP waf_notify_dropped_total Backend notifications (alerts) dropped because the queue was full.\n"+
 			"# TYPE waf_notify_dropped_total counter\n"+
-			"waf_notify_dropped_total %d\n",
+			"waf_notify_dropped_total %d\n"+
+			"# HELP waf_body_truncated_total Requests whose body exceeded the inspection limit (only a prefix was scanned).\n"+
+			"# TYPE waf_body_truncated_total counter\n"+
+			"waf_body_truncated_total %d\n"+
+			"# HELP waf_respmod_uninspectable_total Text responses skipped because the body was compressed (coverage gap).\n"+
+			"# TYPE waf_respmod_uninspectable_total counter\n"+
+			"waf_respmod_uninspectable_total %d\n",
 		trafficEnabled,
 		trafficLogDropped.Load(),
 		notifyDropped.Load(),
+		bodyTruncatedCount.Load(),
+		respmodUninspectable.Load(),
 	)
 
 	// REQMOD inspection latency histogram → enables p50/p95/p99 in Prometheus.

--- a/waf-go/normalize.go
+++ b/waf-go/normalize.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"regexp"
 	"strings"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // textContentTypes lists Content-Type prefixes for which body inspection is meaningful.
@@ -24,6 +26,11 @@ var (
 	reNullBytes    = regexp.MustCompile("(%00|\\\\x00|&#0+;?|\x00)")
 	reMultiSpace   = regexp.MustCompile(`\s{2,}`)
 	reAllSpace     = regexp.MustCompile(`\s+`)
+	// Comment forms used to break keywords apart for evasion, e.g. UN/**/ION,
+	// <scr<!-- -->ipt>. Stripped in the compacted scan form (non-greedy, dot
+	// matches newlines via the (?s) flag so multi-line comments collapse too).
+	reBlockComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	reHTMLComment  = regexp.MustCompile(`(?s)<!--.*?-->`)
 )
 
 // normalizeInput applies anti-evasion transformations to the input.
@@ -50,6 +57,24 @@ func normalizeInput(input string) string {
 	// HTML entity decode
 	s = html.UnescapeString(s)
 
+	// Unicode NFKC fold: maps compatibility variants (fullwidth ＳＥＬＥＣＴ, ligatures,
+	// circled/wide forms) to their ASCII equivalents, defeating homoglyph evasion
+	// of keywords like <script>/SELECT that the regex rules expect in ASCII.
+	if !isASCII(s) {
+		s = norm.NFKC.String(s)
+	}
+
+	// Strip inline comments used to break keywords apart, replacing each with a
+	// SPACE so token boundaries are preserved the way the DB/HTML parser sees them
+	// (MySQL treats /**/ as whitespace): UNION/**/SELECT → "UNION SELECT" matches
+	// the SQLi rule; <scr<!-- -->ipt> → "<scr ipt>" then collapses below.
+	if strings.Contains(s, "/*") {
+		s = reBlockComment.ReplaceAllString(s, " ")
+	}
+	if strings.Contains(s, "<!--") {
+		s = reHTMLComment.ReplaceAllString(s, " ")
+	}
+
 	// Remove null bytes
 	s = reNullBytes.ReplaceAllString(s, "")
 
@@ -59,8 +84,20 @@ func normalizeInput(input string) string {
 	return s
 }
 
+// isASCII reports whether s is pure ASCII (fast path to skip NFKC, which is the
+// main per-request allocation cost on the hot path).
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
 // compactInput strips ALL whitespace — catches evasion via space insertion
-// inside keywords (e.g. "<scr ipt>" → "<script>").
+// inside keywords (e.g. "<scr ipt>" → "<script>"). Comments are already turned
+// into spaces by normalizeInput, so by here they are just whitespace.
 func compactInput(s string) string {
 	return reAllSpace.ReplaceAllString(s, "")
 }
@@ -93,6 +130,21 @@ func isLANHost(host string) bool {
 		return false
 	}
 	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
+}
+
+// isCompressedEncoding reports whether a Content-Encoding marks the body as
+// compressed (so the raw bytes are not scannable by the plaintext rules).
+func isCompressedEncoding(enc string) bool {
+	enc = strings.ToLower(strings.TrimSpace(enc))
+	if enc == "" || enc == "identity" {
+		return false
+	}
+	for _, c := range []string{"gzip", "br", "deflate", "compress", "zstd"} {
+		if strings.Contains(enc, c) {
+			return true
+		}
+	}
+	return false
 }
 
 func isTextContent(contentType string) bool {


### PR DESCRIPTION
**Stacked on #141** (Fase 1). Base it there; merge order #140 → #141 → this. Engine-only — the abandoned go-icap transport replacement is **Fase 2b**, a separate PR with its own deploy verification.

## Anti-evasion normalization
- **Inline comment stripping → space**, so token boundaries match what the DB/HTML parser sees:
  - `UNION/**/SELECT` → `UNION SELECT` → trips the SQLi rule
  - `<scr<!-- -->ipt>` → `<scr ipt>` → `<script>`
  - **No false positive**: `UN/**/ION` → `UN ION` (not the `UNION` keyword) stays a non-match — explicitly tested.
- **NFKC unicode fold** (`golang.org/x/text`) so fullwidth/homoglyph keywords (`＜script＞`, `ＳＥＬＥＣＴ`) collapse to the ASCII the rules expect. `isASCII` fast-path keeps the pure-ASCII hot path allocation-free.

## Coverage-gap signals (were silent)
- **Oversize request body**: read 1 byte past the 1 MB limit to detect truncation → corroborating `WAF-BODY-OVERSIZE` score (below threshold, can't block alone) + `waf_body_truncated_total`. A payload hidden behind >1 MB padding is no longer a clean allow.
- **Compressed RESPMOD bodies** (`Content-Encoding: gzip|br|deflate|zstd`) are uninspectable by plaintext rules → flag + `waf_respmod_uninspectable_total` + pass through, instead of "scanning" compressed bytes and reporting clean.

## Rule safety
- Reject **overly-broad custom rules** at load (match empty string, or match every benign sample) — a `.*` rule would otherwise score 7 on all traffic and mass-block.

## New metrics
`waf_body_truncated_total`, `waf_respmod_uninspectable_total`.

## Verification
- Build, vet, full suite, `-race` (84s) all green.
- New tests: `TestNormalizationDefeatsEvasion` (incl. non-FP case), `TestOversizeBodyFlagged`, `TestRespmodCompressedIsUninspectable`, `TestIsCompressedEncoding`, `TestOverlyBroadRule`.
- `FuzzNormalizeInput` + `FuzzMatchRules`: 400k+ execs, no panics.

## Noted for Fase 2b (not in this PR)
A 1 MB single-char body scan takes ~3s across 170 rules × 2 forms — a real latency/DoS concern (now visible via the Fase 1 `waf_reqmod_duration_seconds` histogram). Streaming/early-exit and the keep-alive ICAP transport are the 2b work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)