### PR TITLE
docs: document v3.10.0 observability + correct WAF rule count

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ notifications) is managed from the UI and stored in the database, not in `.env`.
   Egress Allowlist page.
 
 **WAF**
-- 175 regex rules across 23 toggleable categories (SQLi, XSS, traversal, C2,
+- 170 regex rules across 21 toggleable categories (SQLi, XSS, traversal, C2,
   data-loss, etc.), each enableable/disableable at runtime.
 - 7 behavioural heuristics (entropy, beaconing, PII, sharding, morphing,
   ghosting, sequence) plus DGA detection (bigram + entropy), typosquatting
@@ -119,7 +119,14 @@ notifications) is managed from the UI and stored in the database, not in `.env`.
 **Operations**
 - Live dashboard, per-client drill-down, searchable access logs, and an audit
   log of configuration changes.
-- Prometheus metrics from the WAF at `:8080/metrics` (aggregate counters only).
+- Prometheus metrics on the internal network: the backend at `:5000/metrics`
+  (RED metrics per route, DB connection-pool gauges, worker heartbeats, Go
+  runtime) and the WAF at `:8080/metrics` (counters plus a REQMOD latency
+  histogram). An opt-in `observability` Compose profile ships Prometheus +
+  Grafana: `docker compose --profile observability up -d`.
+- Health probes: `/livez` (process up) and `/readyz` (database reachable — the
+  container healthcheck uses this so a wedged DB surfaces as unhealthy).
+  Structured per-request access logs on the backend.
 - Notifications to a custom webhook, Gotify, Telegram, or Microsoft Teams, with
   retry and backoff.
 - WebSocket log streaming, JWT auth with a persistent revocation list, per-IP

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -35,7 +35,7 @@ Secure Proxy Manager is a multi-service Docker Compose application. Each service
 │                         ▼                                       │
 │              waf  (internal port 1344)                          │
 │              Go ICAP server                                     │
-│              175 regex rules + 7 behavioural heuristics         │
+│              170 regex rules + 7 behavioural heuristics         │
 │              Notifies backend at POST /api/internal/alert       │
 │                                                                 │
 │              dns  (internal port 53)                            │
@@ -65,6 +65,8 @@ The `frontend` network connects `web` to `backend`. The `proxy-internal` network
 - Applies blacklist and whitelist changes by writing files under `/config/` and signalling the proxy or DNS service to reload.
 - When default-deny egress is enabled, exports the `dst_allowlist` table to `/config/dst_allow_ip.txt` (CIDR entries) and `/config/dst_allow_domain.txt` (domain entries), both written atomically, and writes the flag file `/config/egress_default_deny` to reflect the toggle.
 - WebSocket endpoint at `/api/ws/logs` broadcasts new log entries to connected UI clients.
+- Liveness at `/livez` (and `/health`); readiness at `/readyz` (pings the database) — the container healthcheck uses readiness, so a wedged database is reported as unhealthy.
+- Prometheus metrics at `/metrics` (RED metrics per route, DB connection-pool gauges, per-worker heartbeats, Go runtime), plus a structured access-log line per request. The endpoint is internal-only — nginx does not proxy it.
 
 ### `proxy` — Squid
 
@@ -80,12 +82,15 @@ The `frontend` network connects `web` to `backend`. The `proxy-internal` network
 ### `waf` — Go ICAP server
 
 - Listens for ICAP `REQMOD` (and limited `RESPMOD`) on port `1344`.
-- Applies 175 regex rules across 23 categories (SQL injection, XSS, directory traversal, command injection, Unicode homograph obfuscation, response XSS, response secret leak, and more).
+- Applies 170 regex rules across 21 categories (SQL injection, XSS, directory traversal, command injection, Unicode homograph obfuscation, response XSS, response secret leak, and more).
 - Seven behavioural heuristics: entropy thresholding, C2 beaconing detection, PII leak counting, destination sharding, protocol ghosting, header morphing, sequence validation. Each heuristic is individually toggleable via the `WAF_H_*` environment variables.
 - Anomaly scoring with a configurable threshold (`WAF_BLOCK_THRESHOLD`, default `10`).
-- Loads custom regex patterns from `/config/waf_custom_rules.txt` at startup (one pattern per line, `#` for comments).
+- Anti-evasion input normalization: multi-pass URL/HTML decode, inline SQL/HTML comment stripping (so `UNION/**/SELECT` is caught), and NFKC Unicode folding to defeat fullwidth/homoglyph keyword variants.
+- Loads custom regex patterns from `/config/waf_custom_rules.txt` at startup (one pattern per line, `#` for comments); over-broad patterns that would match everything are rejected.
 - Tar-pits repeat offenders: clients seen with three or more blocks within sixty seconds are delayed by ten seconds per request.
 - Notifies the backend of blocks via authenticated `POST /api/internal/alert`.
+- Emits an `ISTag` (RFC 3507) on ICAP responses, derived from the ruleset and bumped on category toggles, so Squid invalidates cached verdicts when rules change.
+- Prometheus metrics at `:8080/metrics`: aggregate counters, a REQMOD latency histogram, and coverage-gap counters (traffic-log enabled/dropped, oversize bodies, uninspectable compressed responses).
 
 ### `dns` — dnsmasq sinkhole
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -86,11 +86,31 @@ docker compose up -d
 # All services running and healthy
 docker compose ps
 
-# Backend health (localhost only)
+# Backend liveness (localhost only)
 curl -k https://localhost:8443/health
+
+# Backend readiness — checks the database is reachable (503 if not)
+docker compose exec backend wget -qO- http://localhost:5000/readyz
 
 # Test proxy connectivity
 curl -x http://localhost:3128 http://example.com
+```
+
+## Metrics and Grafana
+
+The backend and WAF expose Prometheus metrics on their internal ports (not
+proxied by nginx, so not reachable from outside the Docker network):
+
+```bash
+docker compose exec backend wget -qO- http://localhost:5000/metrics | head
+docker compose exec waf     wget -qO- http://localhost:8080/metrics | head
+```
+
+To get a ready-made Prometheus + Grafana stack scraping both, start the opt-in
+`observability` profile (Grafana on `127.0.0.1:3000`, Prometheus on `:9090`):
+
+```bash
+docker compose --profile observability up -d
 ```
 
 ## Troubleshooting

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -11,7 +11,7 @@ It is intended for homelab operators and small networks that need a manageable, 
 - **Egress allowlist.** Optional default-deny outbound egress that turns the proxy into a strict egress gateway. When enabled, local clients may reach only the destinations on an explicit allowlist of IP/CIDR and domain entries; everything else is refused. Off by default — when off, behaviour is unchanged and clients may reach any destination not on a blacklist.
 - **IP whitelist.** Trusted destination IPs that bypass the direct-IP block rule.
 - **Domain whitelist.** Domains excluded from the dnsmasq DNS sinkhole.
-- **WAF.** A Go ICAP server that inspects request payloads with 175 regex rules across 23 categories and 7 behavioural heuristics (entropy, beaconing, PII, sharding, ghosting, morphing, sequence). Limited response inspection (reflected XSS, secret leak, PII) is also performed.
+- **WAF.** A Go ICAP server that inspects request payloads with 170 regex rules across 21 categories and 7 behavioural heuristics (entropy, beaconing, PII, sharding, ghosting, morphing, sequence). Limited response inspection (reflected XSS, secret leak, PII) is also performed.
 - **Real-time logs.** WebSocket-based live log stream with search, filters, and statistics.
 - **Dashboard.** Traffic timeline, security score, blocked counts, top domains and clients.
 - **Blocklist import.** Import from URL or inline content. One-click import of curated public lists (Firehol, Spamhaus, StevenBlack, URLhaus, Phishing Army, and others).

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ features:
   - title: IP whitelist
     details: Whitelist trusted destination IPs to bypass the direct-IP block rule. Useful for LAN devices accessed by IP address.
   - title: ICAP WAF
-    details: Go-based ICAP server inspects HTTP requests with 175 regex rules across 23 categories plus 7 behavioural heuristics. Anomaly scoring with a configurable block threshold.
+    details: Go-based ICAP server inspects HTTP requests with 170 regex rules across 21 categories plus 7 behavioural heuristics. Anomaly scoring with a configurable block threshold.
   - title: Real-time logs
     details: Live log streaming over WebSocket with one-time token authentication. Filter, search, and aggregate access events.
   - title: Hardened by default


### PR DESCRIPTION
Brings README and the VitePress docs in line with the **v3.10.0** codebase.

## Added (observability — previously undocumented)
- Backend Prometheus `/metrics` (RED per route, DB-pool gauges, worker heartbeats, Go runtime) — internal-only, nginx doesn't proxy it.
- WAF REQMOD latency histogram + coverage-gap counters.
- `/livez` + `/readyz` probes (readiness pings the DB; healthcheck uses it).
- Opt-in `observability` Compose profile (Prometheus + Grafana): `docker compose --profile observability up -d`.
- WAF ISTag (RFC 3507) + anti-evasion normalization (comment-strip + NFKC) notes.

## Corrected
- WAF rule count was a stale **175 rules / 23 categories**; the engine actually initialises **170 rules / 21 categories** (verified from the runtime init log). Fixed across README, `index.md`, `introduction.md`, `architecture.md`.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)