### PR TITLE
chore(release): v3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.1] - 2026-06-27
+
+### Added
+
+- **Settings quick-nav.** A full-width sticky chip bar under the Settings header
+  jumps to each section (Proxy, Notifications, DNS & WAF, Access, Certificates,
+  Security, Account) and highlights the active one as you scroll. Makes the long
+  Settings page far quicker to navigate.
+
 ## [3.10.0] - 2026-06-27
 
 ### Added

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.10.0"
+const AppVersion = "3.10.1"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secure-proxy-manager-ui",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secure-proxy-manager-ui",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "dependencies": {
         "@tanstack/react-query": "^5.95.0",
         "axios": "^1.16.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.10.0",
+  "version": "3.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release. Rolls up **#148** — the Settings page full-width sticky quick-nav. Version synced across `version.go`, `ui/package.json` (+ lockfile), `CHANGELOG.md`. Tags after merge to publish signed multi-arch images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)