### PR TITLE
v3.10.4 — fix DNS container unhealthy on deploy (dnsmasq log perms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.4] - 2026-06-29
+
+### Fixed
+
+- **DNS container unhealthy on real deploys (regression in 3.10.3).** The
+  docker-decouple pointed dnsmasq's query log at `/var/log/dnsmasq.log` on the
+  shared `./logs` bind-mount so the backend DNS tailer could read it, but the
+  unprivileged user dnsmasq drops to could not write the root-owned file and
+  exited in a restart loop (`cannot open log …: Permission denied`). The log is
+  now `chown`ed to the `dnsmasq` user and dnsmasq runs with `--user=dnsmasq`, so
+  it works regardless of the host directory's ownership. (CI masked this by
+  making `./logs` world-writable; real deploys do not.)
+
 ## [3.10.3] - 2026-06-29
 
 ### Added

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.10.3"
+const AppVersion = "3.10.4"

--- a/dns/entrypoint.sh
+++ b/dns/entrypoint.sh
@@ -135,17 +135,29 @@ watch_dnsmasq() {
 # Start background watchdog
 watch_dnsmasq &
 
-# Ensure query log directory and file exist with correct permissions
+# Ensure the query log exists and is writable by the unprivileged user dnsmasq
+# drops to. /var/log is a bind-mount (host ./logs) owned by a UID that differs
+# from dnsmasq's runtime user, so a root-created 0644 file is NOT writable after
+# the privilege drop and dnsmasq exits with "cannot open log ...: Permission
+# denied". chown the file to the dnsmasq user (we run as root here) so this works
+# regardless of the host directory's ownership. (CI masks this by making ./logs
+# world-writable; real deploys do not — this is the host-independent fix.)
 mkdir -p /var/log
 touch /var/log/dnsmasq.log
-chmod 0644 /var/log/dnsmasq.log
+if chown dnsmasq:dnsmasq /var/log/dnsmasq.log 2>/dev/null; then
+    chmod 0644 /var/log/dnsmasq.log
+else
+    chmod 0666 /var/log/dnsmasq.log
+fi
 
 # Foreground loop to restart dnsmasq process on configuration toggle trigger
 while true; do
     build_dnsmasq_conf
-    
+
     echo "Starting dnsmasq..."
-    dnsmasq --no-daemon --log-queries --log-facility=/var/log/dnsmasq.log --conf-file=/tmp/dnsmasq.conf
+    # --user=dnsmasq: run as the same user that owns the log above (explicit, so
+    # we don't depend on the compiled-in default), keeping least privilege.
+    dnsmasq --no-daemon --user=dnsmasq --log-queries --log-facility=/var/log/dnsmasq.log --conf-file=/tmp/dnsmasq.conf
     
     echo "dnsmasq process exited, restarting in 1 second..."
     sleep 1

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.10.3",
+  "version": "3.10.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch hotfix for a **3.10.3 deploy regression**: the DNS container went
unhealthy on real hosts and aborted `promote`.

## Root cause
3.10.3's docker-decouple points dnsmasq's query log at `/var/log/dnsmasq.log`
on the shared `./logs` bind-mount (so the backend DNS sinkhole tailer can read
it). dnsmasq drops privileges and could not write the root-created, root-owned
file → restart loop (`cannot open log …: Permission denied`) → unhealthy.

CI did not catch it because `tests/ci-e2e.sh` does `chmod -R a+rwX ./logs`,
making the log world-writable; real deploys keep restrictive perms.

## Fix
`chown` the log to the `dnsmasq` user and run `dnsmasq --user=dnsmasq`, so the
runtime user owns and can write the log **regardless of the host directory's
ownership**.

## Verification
Faithful end-to-end test on a real host against a restrictive (`uid13`-owned,
`0755`) `/var/log`: the fixed entrypoint keeps dnsmasq up, writes a
`dnsmasq`-owned query log, and emits no permission error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)