### PR TITLE
v3.10.5 — fix DNS unhealthy for real (CAP_DAC_OVERRIDE on dns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.5] - 2026-06-29
+
+### Fixed
+
+- **DNS container still unhealthy on deploy (follow-up to 3.10.4).** The real
+  cause was not the log file's owner but `cap_drop: ALL` on the dns service:
+  without `CAP_DAC_OVERRIDE`, even root cannot create/write dnsmasq's query log
+  on the shared `./logs` bind-mount (owned by the proxy's UID), so dnsmasq looped
+  on `cannot open log …: Permission denied` and the container never went healthy.
+  Add `CAP_DAC_OVERRIDE` to the dns service and run `dnsmasq --user=root` so it
+  keeps that capability to write the log. Verified end-to-end against a
+  restrictive bind-mount with the exact runtime caps (dnsmasq healthy, log
+  written, no permission error). The proxy was unaffected because squid runs as
+  the same UID that owns `./logs`.
+
 ## [3.10.4] - 2026-06-29
 
 ### Fixed

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.10.4"
+const AppVersion = "3.10.5"

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -168,6 +168,9 @@ services:
       - ALL
     cap_add:
       - NET_BIND_SERVICE
+      # DAC_OVERRIDE: dnsmasq writes its query log to the shared ./logs mount
+      # (different UID); with cap_drop: ALL even root needs this to write there.
+      - DAC_OVERRIDE
     logging:
       driver: json-file
       options:

--- a/dns/entrypoint.sh
+++ b/dns/entrypoint.sh
@@ -135,29 +135,25 @@ watch_dnsmasq() {
 # Start background watchdog
 watch_dnsmasq &
 
-# Ensure the query log exists and is writable by the unprivileged user dnsmasq
-# drops to. /var/log is a bind-mount (host ./logs) owned by a UID that differs
-# from dnsmasq's runtime user, so a root-created 0644 file is NOT writable after
-# the privilege drop and dnsmasq exits with "cannot open log ...: Permission
-# denied". chown the file to the dnsmasq user (we run as root here) so this works
-# regardless of the host directory's ownership. (CI masks this by making ./logs
-# world-writable; real deploys do not — this is the host-independent fix.)
+# /var/log is the shared ./logs bind-mount, owned by a different UID than this
+# container (the proxy creates those files as its own user). With cap_drop: ALL
+# even root is subject to DAC checks, so writing there needs CAP_DAC_OVERRIDE
+# (added to the dns service) AND dnsmasq must stay root to keep that capability —
+# dropping to an unprivileged user would lose it and fail with "cannot open log
+# …: Permission denied". (CI masks this by chmod a+rwX on ./logs; real deploys
+# keep restrictive perms — this is the host-independent fix.)
 mkdir -p /var/log
-touch /var/log/dnsmasq.log
-if chown dnsmasq:dnsmasq /var/log/dnsmasq.log 2>/dev/null; then
-    chmod 0644 /var/log/dnsmasq.log
-else
-    chmod 0666 /var/log/dnsmasq.log
-fi
+touch /var/log/dnsmasq.log 2>/dev/null || true
+chmod 0644 /var/log/dnsmasq.log 2>/dev/null || true
 
 # Foreground loop to restart dnsmasq process on configuration toggle trigger
 while true; do
     build_dnsmasq_conf
 
     echo "Starting dnsmasq..."
-    # --user=dnsmasq: run as the same user that owns the log above (explicit, so
-    # we don't depend on the compiled-in default), keeping least privilege.
-    dnsmasq --no-daemon --user=dnsmasq --log-queries --log-facility=/var/log/dnsmasq.log --conf-file=/tmp/dnsmasq.conf
+    # --user=root: keep CAP_DAC_OVERRIDE so dnsmasq can write its query log on
+    # the shared, differently-owned ./logs mount (the container is already root).
+    dnsmasq --no-daemon --user=root --log-queries --log-facility=/var/log/dnsmasq.log --conf-file=/tmp/dnsmasq.conf
     
     echo "dnsmasq process exited, restarting in 1 second..."
     sleep 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,6 +175,10 @@ services:
       - ALL
     cap_add:
       - NET_BIND_SERVICE
+      # DAC_OVERRIDE: dnsmasq writes its query log to the shared ./logs mount,
+      # which is owned by a different UID; with cap_drop: ALL even root needs this
+      # to write there (see dns/entrypoint.sh).
+      - DAC_OVERRIDE
     logging:
       driver: json-file
       options:

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.10.4",
+  "version": "3.10.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Follow-up to v3.10.4 — the DNS container was **still unhealthy** on deploy.

## Real root cause
Not the log file's owner (3.10.4's guess) but **`cap_drop: ALL`** on the dns
service: without `CAP_DAC_OVERRIDE`, even root is subject to DAC checks and
cannot create/write dnsmasq's query log on the shared `./logs` bind-mount, which
is owned by the proxy's UID. dnsmasq looped on `cannot open log …: Permission
denied` → never healthy → `promote` aborted (fail-fast on dev).

Proven on the host: `touch /var/log/dnsmasq.log` as **root** returns
`Permission denied` with `cap_drop: ALL`; adding `CAP_DAC_OVERRIDE` fixes it.
The proxy was unaffected because squid runs as the same UID that owns `./logs`.

## Fix
- Add `CAP_DAC_OVERRIDE` to the dns service (`docker-compose.yml` + `deploy/docker-compose.prod.yml`).
- `dnsmasq --user=root` so it keeps the capability to write the log.

## Verification (faithful)
Ran the dns image with the **exact** runtime flags (`--cap-drop ALL
--cap-add NET_BIND_SERVICE --cap-add DAC_OVERRIDE --read-only`, uid13-owned
`/var/log`): container stays up, `nslookup localhost` answers on `:53`
(healthcheck passes), query log written, no permission error.

Note: CI did not catch this because `tests/ci-e2e.sh` does `chmod -R a+rwX ./logs`,
making the mount world-writable; real hosts keep restrictive perms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)