### PR TITLE
v3.11.1 — proxy self-heals stale dnsmasq/waf IPs (fixes 502 after container recreate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.1] - 2026-06-29
+
+### Fixed
+
+- **Proxy 502 after the dns (or waf) container is recreated.** squid bakes the
+  dnsmasq IP (`dns_nameservers`) and the WAF ICAP IP into its config at
+  generation time; when those containers are recreated they get new IPs, leaving
+  squid pointing at dead addresses — every request 502s (dns) or skips ICAP
+  (waf) until the proxy is manually restarted. The in-container watchdog now
+  tracks the resolved dns/waf IPs and, on drift, regenerates the squid config
+  and reconfigures in place (self-healing within ~2s, no proxy restart). This
+  surfaced live during the 3.11.0 dev deploy (a partial rebuild recreated dns
+  but not the proxy). A full `compose up` after a full build was already safe via
+  dependency ordering; this covers partial deploys and ad-hoc recreates too.
+
 ## [3.11.0] - 2026-06-29
 
 Hardening sweep across CI/release rigor, UX correctness, deployment robustness,

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.11.0"
+const AppVersion = "3.11.1"

--- a/proxy/blacklist_watchdog.py
+++ b/proxy/blacklist_watchdog.py
@@ -19,6 +19,7 @@ squid-supervisor.conf (rather than generated at runtime) so supervisord always
 picks it up on a fresh boot.
 """
 import os
+import socket
 import subprocess
 import time
 
@@ -48,6 +49,24 @@ def mtime(path):
         return 0
 
 
+def resolved_ips():
+    """Current IPs of the dns + waf service names (via Docker's embedded DNS).
+
+    squid bakes these IPs into squid.conf at config-generation time
+    (dns_nameservers for dnsmasq, the ICAP service URL for the WAF). When those
+    containers are recreated they get NEW IPs, leaving squid pointing at dead
+    addresses — 502 on every request (dns) or ICAP failures (waf). We track the
+    resolved IPs so the loop can detect that drift and regenerate in place.
+    """
+    ips = []
+    for name in ("dns", "waf"):
+        try:
+            ips.append(socket.gethostbyname(name))
+        except OSError:
+            ips.append("")
+    return ",".join(ips)
+
+
 def main():
     import shutil
 
@@ -67,8 +86,27 @@ def main():
     except Exception as exc:
         print(f"[watchdog] squid version check failed: {exc}", flush=True)
 
+    # Baseline = the IPs squid was configured with at startup (startup.sh ran
+    # generate_squid_conf.sh against the same resolution).
+    resolv_fp = resolved_ips()
+
     while True:
         time.sleep(2)
+
+        # Self-heal stale dnsmasq/waf IPs: if either service was recreated and
+        # got a new IP, squid's baked dns_nameservers / ICAP URL now point at a
+        # dead address (502 on every request, or ICAP failures). Regenerate the
+        # config (re-resolves both) and reconfigure in place. Guard on both being
+        # resolvable so a transient lookup miss doesn't trigger a needless reload.
+        fp = resolved_ips()
+        if fp != resolv_fp and all(fp.split(",")):
+            print(f"[watchdog] resolver drift {resolv_fp} -> {fp}, regenerating config...", flush=True)
+            try:
+                subprocess.run(["/usr/local/bin/generate_squid_conf.sh"], capture_output=True, timeout=30)
+                subprocess.run(["/usr/sbin/squid", "-k", "reconfigure"], capture_output=True, timeout=10)
+                resolv_fp = fp
+            except Exception as exc:  # noqa: BLE001
+                print(f"[watchdog] resolver-drift reload error: {exc}", flush=True)
 
         # Periodically dump Squid cache stats to a shared file in /config
         if time.time() - last_stats_time > 10:

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secure-proxy-manager-ui",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secure-proxy-manager-ui",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@tanstack/react-query": "^5.95.0",
         "axios": "^1.16.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.11.0",
+  "version": "3.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Problem (found live during the 3.11.0 dev deploy)
squid bakes the dnsmasq IP (`dns_nameservers`) and the WAF ICAP IP into its
config at generation time. Recreating the dns/waf container gives it a **new
IP**, so squid points at a dead address → **502 on every request** (dns) or
silent ICAP skips (waf) until the proxy is manually restarted.

A full `compose up` after a full build is already safe (proxy is recreated after
dns via `depends_on` ordering), but a **partial rebuild** (recreate dns only) or
an ad-hoc `compose up -d dns` leaves the proxy stale — which is exactly what bit
the 3.11.0 dev deploy.

## Fix
The in-container watchdog tracks the resolved `dns`/`waf` IPs and, on drift,
re-runs `generate_squid_conf.sh` + `squid -k reconfigure` **in place** —
self-healing within ~2s, no restart. Host-agnostic: no static-subnet pinning
(which would risk subnet collisions on shared hosts).

## Validation
Local: py_compile + version-sync. Post-merge I'll deploy to dev and prove it by
recreating the dns container and confirming proxy egress stays/returns 204
without a manual proxy restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)