### PR TITLE
security: strict Base64URL JWT decoding + v3.11.2 (GHSA-j5fj-8wxc-gvmj)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.2] - 2026-07-25
+
+### Security
+
+- **Logout / token-revocation bypass via alternate JWT spelling
+  ([GHSA-j5fj-8wxc-gvmj], CWE-613, CVSS 6.3).** The revocation blacklist is keyed
+  by the SHA-256 of the compact JWT string, but `golang-jwt` decodes Base64URL
+  non-strictly by default: a token whose final signature character is swapped for
+  an equivalent spelling (only unused bits differ) decodes to the same signature
+  bytes — so it still validates — yet hashes to a different blacklist key. A
+  holder of a valid token could therefore keep authenticating after logout, and
+  defeat one-time refresh-token rotation, using an equivalent spelling. Fixed by
+  pinning `jwt.WithStrictDecoding()` at all three parse sites (`ValidateJWT`,
+  `ValidateRefreshToken`, `tokenExpiry`), so only the canonical spelling parses
+  and the string↔token identity the blacklist relies on is restored. Adds an
+  HTTP-level regression test. Reported under coordinated disclosure by a UC
+  Berkeley security research project: Corban Villa, Sohee Kim, and Austin Chu.
+
+[GHSA-j5fj-8wxc-gvmj]: https://github.com/fabriziosalmi/secure-proxy-manager/security/advisories/GHSA-j5fj-8wxc-gvmj
+
 ## [3.11.1] - 2026-06-29
 
 ### Fixed

--- a/backend-go/internal/auth/auth.go
+++ b/backend-go/internal/auth/auth.go
@@ -23,7 +23,14 @@ import (
 	"github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/config"
 )
 
-// tokenHash returns a hex-encoded SHA-256 hash of a JWT string.
+// tokenHash returns a hex-encoded SHA-256 hash of a JWT string. It is the
+// revocation-blacklist key, so it MUST uniquely identify a token. That holds
+// only because every jwt.Parse call site pins jwt.WithStrictDecoding():
+// golang-jwt decodes Base64URL non-strictly by default, so distinct compact
+// spellings (unused signature bits flipped) would otherwise decode to the same
+// signature bytes, validate, yet hash differently — letting a revoked token be
+// replayed under an equivalent spelling (GHSA-j5fj-8wxc-gvmj). Strict decoding
+// makes only the canonical spelling parse, restoring the 1:1 string↔token map.
 func tokenHash(token string) string {
 	h := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(h[:])
@@ -148,7 +155,7 @@ func (s *Service) ValidateRefreshToken(tokenStr string) (string, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return []byte(s.cfg.SecretKey), nil
-	})
+	}, jwt.WithStrictDecoding())
 	if err != nil || !token.Valid {
 		return "", errors.New("invalid or expired refresh token")
 	}
@@ -176,7 +183,7 @@ func (s *Service) ValidateJWT(tokenStr string) (string, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return []byte(s.cfg.SecretKey), nil
-	})
+	}, jwt.WithStrictDecoding())
 	if err != nil || !token.Valid {
 		return "", errors.New("invalid or expired token")
 	}
@@ -222,7 +229,7 @@ func (s *Service) tokenExpiry(tokenStr string) time.Time {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return []byte(s.cfg.SecretKey), nil
-	})
+	}, jwt.WithStrictDecoding())
 	if err == nil && token != nil {
 		if claims, ok := token.Claims.(jwt.MapClaims); ok {
 			if expClaim, e := claims.GetExpirationTime(); e == nil && expClaim != nil {

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.11.1"
+const AppVersion = "3.11.2"

--- a/backend-go/internal/handlers/jwt_revocation_test.go
+++ b/backend-go/internal/handlers/jwt_revocation_test.go
@@ -1,0 +1,133 @@
+package handlers
+
+// Regression test for GHSA-j5fj-8wxc-gvmj — "Logout Bypass via Alternate JWT
+// Spelling" (CWE-613 Insufficient Session Expiration).
+//
+// The revocation blacklist is keyed by SHA-256 of the compact JWT string, but
+// golang-jwt decodes Base64URL non-strictly by default: a token whose final
+// signature character is swapped for an equivalent spelling (only unused bits
+// differ) decodes to the same signature bytes, so it still validates — yet
+// hashes to a different blacklist key. Before the fix, such an "equivalent
+// spelling" was accepted AFTER the original had been revoked at logout,
+// defeating token revocation. The fix pins jwt.WithStrictDecoding() at every
+// parse site so only the canonical spelling parses.
+//
+// Reported under coordinated disclosure by a UC Berkeley security research
+// project: Corban Villa (@corbanvilla), Sohee Kim (@soh3e), and Austin Chu
+// (@dderpym). This test is adapted from the proof-of-concept in their advisory,
+// with the post-fix expectation: the equivalent spelling must now be rejected.
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// equivalentJWT returns a distinct compact spelling of token that decodes to
+// the same signature bytes (a non-canonical Base64URL spelling of the final
+// character). It fails the test if no such alias exists for this signature.
+func equivalentJWT(t *testing.T, token string) string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	for _, character := range alphabet {
+		alias := parts[2][:len(parts[2])-1] + string(character)
+		decoded, err := base64.RawURLEncoding.DecodeString(alias)
+		if alias != parts[2] && err == nil && bytes.Equal(decoded, signature) {
+			return strings.Join([]string{parts[0], parts[1], alias}, ".")
+		}
+	}
+	t.Fatal("no equivalent signature spelling")
+	return ""
+}
+
+func TestJWTRevocationBypassThroughHTTP(t *testing.T) {
+	db, service, cfg, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	router := chi.NewRouter()
+	NewAuthHandlers(db, service, cfg, nil, nil).Register(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	request := func(method, path, token, body string) int {
+		req, err := http.NewRequest(method, server.URL+path, strings.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		response, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		io.Copy(io.Discard, response.Body)
+		return response.StatusCode
+	}
+
+	login, err := http.Post(
+		server.URL+"/api/auth/login",
+		"application/json",
+		strings.NewReader(`{"username":"admin","password":"admin-12345"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer login.Body.Close()
+	var tokens map[string]string
+	if err := json.NewDecoder(login.Body).Decode(&tokens); err != nil {
+		t.Fatal(err)
+	}
+	original := tokens["access_token"]
+	if original == "" {
+		t.Fatal("login did not return an access_token")
+	}
+	alternate := equivalentJWT(t, original)
+
+	// A token whose signature bytes differ (first char changed) must always be
+	// rejected — this guards the equivalentJWT helper against silently testing a
+	// still-valid signature.
+	parts := strings.Split(original, ".")
+	replacement := "A"
+	if parts[2][0] == 'A' {
+		replacement = "B"
+	}
+	tampered := strings.Join(
+		[]string{parts[0], parts[1], replacement + parts[2][1:]},
+		".",
+	)
+
+	checks := []struct {
+		label, method, path, token string
+		want                       int
+	}{
+		{"baseline", "GET", "/api/ws-token", original, http.StatusOK},
+		{"logout", "POST", "/api/logout", original, http.StatusOK},
+		{"revoked original", "GET", "/api/ws-token", original, http.StatusUnauthorized},
+		// Pre-fix this returned 200 (the bypass). WithStrictDecoding() makes the
+		// non-canonical spelling fail to parse, so it is now rejected as invalid.
+		{"equivalent spelling", "GET", "/api/ws-token", alternate, http.StatusUnauthorized},
+		{"tampered signature", "GET", "/api/ws-token", tampered, http.StatusUnauthorized},
+	}
+	for _, check := range checks {
+		got := request(check.method, check.path, check.token, "")
+		t.Logf("%s: %d", check.label, got)
+		if got != check.want {
+			t.Fatalf("%s: got %d, want %d", check.label, got, check.want)
+		}
+	}
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1101,7 +1101,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -1126,9 +1126,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2396,9 +2396,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2431,9 +2431,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3335,9 +3335,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3346,8 +3346,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -4708,9 +4708,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4979,9 +4979,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4999,7 +4999,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5304,9 +5304,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5326,12 +5326,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secure-proxy-manager-ui",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secure-proxy-manager-ui",
-      "version": "3.11.1",
+      "version": "3.11.2",
       "dependencies": {
         "@tanstack/react-query": "^5.95.0",
         "axios": "^1.16.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.11.1",
+  "version": "3.11.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Fixes **GHSA-j5fj-8wxc-gvmj** — *Logout Bypass via Alternate JWT Spelling* (CWE-613, CVSS 6.3) — and releases **v3.11.2**.

## Root cause
The revocation blacklist is keyed by `SHA-256(compact JWT string)`, but `golang-jwt/jwt/v5` decodes Base64URL **non-strictly** by default. A token whose final signature character is swapped for an equivalent spelling (only unused bits differ) decodes to the same signature bytes — so it still validates — yet hashes to a **different** blacklist key. A holder of a valid token could keep authenticating after logout, and defeat one-time refresh-token rotation, via an equivalent spelling. Access tokens live 8h, refresh tokens 7 days.

## Fix
Pin `jwt.WithStrictDecoding()` at all three parse sites (`ValidateJWT`, `ValidateRefreshToken`, `tokenExpiry`) so only the canonical spelling parses, restoring the 1:1 token-string↔token identity the SHA-256 blacklist relies on. Non-canonical spellings are rejected as invalid before the blacklist is consulted.

## Test
Adds `jwt_revocation_test.go`, an HTTP-level regression test adapted from the reporters' PoC. Asserts the equivalent spelling is now `401` (was `200` pre-fix). Verified failing without the fix, passing with it.

## Release
Bumps version to **3.11.2** across version.go / package.json / package-lock.json / CHANGELOG (version-sync green).

## Attribution
Reported under coordinated disclosure by a UC Berkeley security research project: Corban Villa (@corbanvilla), Sohee Kim (@soh3e), Austin Chu (@dderpym). Remediation and PoC adapted from their advisory, with thanks.

Reported-by: Corban Villa <5652142+corbanvilla@users.noreply.github.com>
Reported-by: Sohee Kim <92657104+soh3e@users.noreply.github.com>
Reported-by: Austin Chu <53957158+dderpym@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)