### PR TITLE
ci: allowlist non-applicable CVE advisories + bump docs deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,13 @@ jobs:
         working-directory: ui
         run: |
           npm ci
-          # Gate on HIGH (not just critical): the react-router CVE wave that
-          # shipped in v3.4.5 (GHSA turbo-stream RCE + 2 XSS) was rated HIGH and
-          # silently passed a critical-only gate. Moderate is intentionally not
-          # gated (current brace-expansion devDep advisory has no clean fix).
-          npm audit --audit-level=high
+          # Gate on HIGH/CRITICAL via an allowlisting wrapper. Plain
+          # `npm audit --audit-level=high` has no ignore mechanism, so one
+          # non-applicable or dev-only HIGH advisory red-gates every unrelated
+          # PR. The wrapper fails on HIGH/CRITICAL EXCEPT advisories explicitly
+          # justified in scripts/npm-audit-allowlist.json, and prints those it
+          # ignores on every run. Moderate stays ungated.
+          node ../scripts/npm-audit-gate.mjs
 
   # ── 6b. Trivy filesystem CVE + misconfiguration scan ──────────────────
   # Catches vulnerable OS/library packages and IaC misconfigurations that gosec

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,9 @@
+# Trivy vulnerability allowlist. ONLY for advisories that are non-applicable or
+# dev-only with no proportionate fix; every entry needs a justification.
+# Keep in sync with scripts/npm-audit-allowlist.json.
+
+# react-router — RSC Mode CSRF. NOT APPLICABLE: this SPA uses react-router-dom in
+# client-side/data mode, not RSC framework mode, so the vulnerable RSC action path
+# is never mounted. No forward fix for react-router-dom exists (no 8.x); the only
+# remediation is a react-router v7->v8 migration. Tracked follow-up: migrate to v8.
+GHSA-qwww-vcr4-c8h2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.2] - 2026-07-25
+
+### Security
+
+- **Logout / token-revocation bypass via alternate JWT spelling
+  ([GHSA-j5fj-8wxc-gvmj], CWE-613, CVSS 6.3).** The revocation blacklist is keyed
+  by the SHA-256 of the compact JWT string, but `golang-jwt` decodes Base64URL
+  non-strictly by default: a token whose final signature character is swapped for
+  an equivalent spelling (only unused bits differ) decodes to the same signature
+  bytes — so it still validates — yet hashes to a different blacklist key. A
+  holder of a valid token could therefore keep authenticating after logout, and
+  defeat one-time refresh-token rotation, using an equivalent spelling. Fixed by
+  pinning `jwt.WithStrictDecoding()` at all three parse sites (`ValidateJWT`,
+  `ValidateRefreshToken`, `tokenExpiry`), so only the canonical spelling parses
+  and the string↔token identity the blacklist relies on is restored. Adds an
+  HTTP-level regression test. Reported under coordinated disclosure by a UC
+  Berkeley security research project: Corban Villa, Sohee Kim, and Austin Chu.
+
+[GHSA-j5fj-8wxc-gvmj]: https://github.com/fabriziosalmi/secure-proxy-manager/security/advisories/GHSA-j5fj-8wxc-gvmj
+
 ## [3.11.1] - 2026-06-29
 
 ### Fixed

--- a/backend-go/internal/auth/auth.go
+++ b/backend-go/internal/auth/auth.go
@@ -23,7 +23,14 @@ import (
 	"github.com/fabriziosalmi/secure-proxy-manager/backend-go/internal/config"
 )
 
-// tokenHash returns a hex-encoded SHA-256 hash of a JWT string.
+// tokenHash returns a hex-encoded SHA-256 hash of a JWT string. It is the
+// revocation-blacklist key, so it MUST uniquely identify a token. That holds
+// only because every jwt.Parse call site pins jwt.WithStrictDecoding():
+// golang-jwt decodes Base64URL non-strictly by default, so distinct compact
+// spellings (unused signature bits flipped) would otherwise decode to the same
+// signature bytes, validate, yet hash differently — letting a revoked token be
+// replayed under an equivalent spelling (GHSA-j5fj-8wxc-gvmj). Strict decoding
+// makes only the canonical spelling parse, restoring the 1:1 string↔token map.
 func tokenHash(token string) string {
 	h := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(h[:])
@@ -148,7 +155,7 @@ func (s *Service) ValidateRefreshToken(tokenStr string) (string, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return []byte(s.cfg.SecretKey), nil
-	})
+	}, jwt.WithStrictDecoding())
 	if err != nil || !token.Valid {
 		return "", errors.New("invalid or expired refresh token")
 	}
@@ -176,7 +183,7 @@ func (s *Service) ValidateJWT(tokenStr string) (string, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return []byte(s.cfg.SecretKey), nil
-	})
+	}, jwt.WithStrictDecoding())
 	if err != nil || !token.Valid {
 		return "", errors.New("invalid or expired token")
 	}
@@ -222,7 +229,7 @@ func (s *Service) tokenExpiry(tokenStr string) time.Time {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return []byte(s.cfg.SecretKey), nil
-	})
+	}, jwt.WithStrictDecoding())
 	if err == nil && token != nil {
 		if claims, ok := token.Claims.(jwt.MapClaims); ok {
 			if expClaim, e := claims.GetExpirationTime(); e == nil && expClaim != nil {

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.11.1"
+const AppVersion = "3.11.2"

--- a/backend-go/internal/handlers/jwt_revocation_test.go
+++ b/backend-go/internal/handlers/jwt_revocation_test.go
@@ -1,0 +1,133 @@
+package handlers
+
+// Regression test for GHSA-j5fj-8wxc-gvmj — "Logout Bypass via Alternate JWT
+// Spelling" (CWE-613 Insufficient Session Expiration).
+//
+// The revocation blacklist is keyed by SHA-256 of the compact JWT string, but
+// golang-jwt decodes Base64URL non-strictly by default: a token whose final
+// signature character is swapped for an equivalent spelling (only unused bits
+// differ) decodes to the same signature bytes, so it still validates — yet
+// hashes to a different blacklist key. Before the fix, such an "equivalent
+// spelling" was accepted AFTER the original had been revoked at logout,
+// defeating token revocation. The fix pins jwt.WithStrictDecoding() at every
+// parse site so only the canonical spelling parses.
+//
+// Reported under coordinated disclosure by a UC Berkeley security research
+// project: Corban Villa (@corbanvilla), Sohee Kim (@soh3e), and Austin Chu
+// (@dderpym). This test is adapted from the proof-of-concept in their advisory,
+// with the post-fix expectation: the equivalent spelling must now be rejected.
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// equivalentJWT returns a distinct compact spelling of token that decodes to
+// the same signature bytes (a non-canonical Base64URL spelling of the final
+// character). It fails the test if no such alias exists for this signature.
+func equivalentJWT(t *testing.T, token string) string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	for _, character := range alphabet {
+		alias := parts[2][:len(parts[2])-1] + string(character)
+		decoded, err := base64.RawURLEncoding.DecodeString(alias)
+		if alias != parts[2] && err == nil && bytes.Equal(decoded, signature) {
+			return strings.Join([]string{parts[0], parts[1], alias}, ".")
+		}
+	}
+	t.Fatal("no equivalent signature spelling")
+	return ""
+}
+
+func TestJWTRevocationBypassThroughHTTP(t *testing.T) {
+	db, service, cfg, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	router := chi.NewRouter()
+	NewAuthHandlers(db, service, cfg, nil, nil).Register(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	request := func(method, path, token, body string) int {
+		req, err := http.NewRequest(method, server.URL+path, strings.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		response, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		io.Copy(io.Discard, response.Body)
+		return response.StatusCode
+	}
+
+	login, err := http.Post(
+		server.URL+"/api/auth/login",
+		"application/json",
+		strings.NewReader(`{"username":"admin","password":"admin-12345"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer login.Body.Close()
+	var tokens map[string]string
+	if err := json.NewDecoder(login.Body).Decode(&tokens); err != nil {
+		t.Fatal(err)
+	}
+	original := tokens["access_token"]
+	if original == "" {
+		t.Fatal("login did not return an access_token")
+	}
+	alternate := equivalentJWT(t, original)
+
+	// A token whose signature bytes differ (first char changed) must always be
+	// rejected — this guards the equivalentJWT helper against silently testing a
+	// still-valid signature.
+	parts := strings.Split(original, ".")
+	replacement := "A"
+	if parts[2][0] == 'A' {
+		replacement = "B"
+	}
+	tampered := strings.Join(
+		[]string{parts[0], parts[1], replacement + parts[2][1:]},
+		".",
+	)
+
+	checks := []struct {
+		label, method, path, token string
+		want                       int
+	}{
+		{"baseline", "GET", "/api/ws-token", original, http.StatusOK},
+		{"logout", "POST", "/api/logout", original, http.StatusOK},
+		{"revoked original", "GET", "/api/ws-token", original, http.StatusUnauthorized},
+		// Pre-fix this returned 200 (the bypass). WithStrictDecoding() makes the
+		// non-canonical spelling fail to parse, so it is now rejected as invalid.
+		{"equivalent spelling", "GET", "/api/ws-token", alternate, http.StatusUnauthorized},
+		{"tampered signature", "GET", "/api/ws-token", tampered, http.StatusUnauthorized},
+	}
+	for _, check := range checks {
+		got := request(check.method, check.path, check.token, "")
+		t.Logf("%s: %d", check.label, got)
+		if got != check.want {
+			t.Fatalf("%s: got %d, want %d", check.label, got, check.want)
+		}
+	}
+}

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2106,9 +2106,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2164,9 +2164,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2184,7 +2184,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2516,9 +2516,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/npm-audit-allowlist.json
+++ b/scripts/npm-audit-allowlist.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "GHSA IDs that npm-audit-gate.mjs will NOT fail on. ONLY for advisories that are non-applicable or dev-only with no proportionate fix. Each MUST carry a justification and, ideally, a tracked follow-up. Runtime-reachable advisories must never be listed here — fix them.",
+  "allow": {
+    "GHSA-qwww-vcr4-c8h2": "react-router — RSC Mode CSRF. NOT APPLICABLE: this SPA uses react-router-dom in client-side/data mode, not RSC framework mode, so the vulnerable RSC action path is never mounted. No forward fix exists for react-router-dom (there is no 8.x of react-router-dom); the only remediation is a react-router v7->v8 migration. Tracked follow-up: migrate to react-router v8.",
+    "GHSA-mh99-v99m-4gvg": "brace-expansion — DoS via unbounded expansion. DEV-ONLY: present solely in the eslint devDependency subtree (minimatch); it runs at lint time over trusted glob config, never over attacker input, and ships in no runtime artifact. Forcing brace-expansion>=5.0.8 breaks eslint's minimatch (expand is not a function); the only clean fix is eslint@10 (breaking major). Tracked follow-up: bump eslint to 10."
+  }
+}

--- a/scripts/npm-audit-gate.mjs
+++ b/scripts/npm-audit-gate.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// npm audit gate with an explicit allowlist.
+//
+// Plain `npm audit --audit-level=high` has no ignore mechanism, so a single
+// non-applicable or dev-only HIGH advisory red-gates every unrelated PR. This
+// wrapper fails the build on HIGH/CRITICAL advisories EXCEPT those explicitly
+// allowlisted (with a written justification) in scripts/npm-audit-allowlist.json.
+// Allowlisted advisories are printed on every run — never silently dropped — so
+// the exception stays visible and auditable.
+//
+// Usage: run from the package dir to audit (e.g. `cd ui && node ../scripts/npm-audit-gate.mjs`).
+// Gates on high+critical, matching the previous `--audit-level=high` behaviour.
+
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const GATED = new Set(['high', 'critical'])
+const here = dirname(fileURLToPath(import.meta.url))
+const allowlist = JSON.parse(readFileSync(join(here, 'npm-audit-allowlist.json'), 'utf8')).allow
+
+// `npm audit --json` exits non-zero when it finds anything; capture regardless.
+let report
+try {
+  report = execSync('npm audit --json', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+} catch (e) {
+  report = e.stdout || ''
+}
+if (!report.trim()) {
+  console.error('npm-audit-gate: empty audit output — treating as failure')
+  process.exit(1)
+}
+
+const audit = JSON.parse(report)
+const vulns = audit.vulnerabilities || {}
+
+// Collect distinct GHSA advisories at gated severity from every `via` entry.
+const found = new Map() // ghsa -> { severity, title, pkgs:Set }
+for (const [pkg, v] of Object.entries(vulns)) {
+  for (const via of v.via || []) {
+    if (typeof via !== 'object' || !via.url) continue
+    const sev = (via.severity || v.severity || '').toLowerCase()
+    if (!GATED.has(sev)) continue
+    const ghsa = (via.url.match(/GHSA-[0-9a-z-]+/i) || [via.url])[0]
+    if (!found.has(ghsa)) found.set(ghsa, { severity: sev, title: via.title || '', pkgs: new Set() })
+    found.get(ghsa).pkgs.add(pkg)
+  }
+}
+
+const ignored = []
+const blocking = []
+for (const [ghsa, info] of found) {
+  ;(ghsa in allowlist ? ignored : blocking).push({ ghsa, ...info })
+}
+
+if (ignored.length) {
+  console.log(`npm-audit-gate: ${ignored.length} allowlisted advisory(ies) ignored (see scripts/npm-audit-allowlist.json):`)
+  for (const a of ignored) {
+    console.log(`  - [${a.severity}] ${a.ghsa} (${[...a.pkgs].join(', ')}) — ${a.title}`)
+  }
+}
+
+if (blocking.length) {
+  console.error(`\nnpm-audit-gate: ${blocking.length} non-allowlisted HIGH/CRITICAL advisory(ies):`)
+  for (const a of blocking) {
+    console.error(`  - [${a.severity}] ${a.ghsa} (${[...a.pkgs].join(', ')}) — ${a.title}`)
+    console.error(`    https://github.com/advisories/${a.ghsa}`)
+  }
+  console.error('\nFix them, or (only if non-applicable/dev-only) add a justified entry to scripts/npm-audit-allowlist.json.')
+  process.exit(1)
+}
+
+console.log(`\nnpm-audit-gate: OK — no non-allowlisted HIGH/CRITICAL advisories.`)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1101,7 +1101,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -1126,9 +1126,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2396,9 +2396,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2431,9 +2431,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3335,9 +3335,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3346,8 +3346,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -4708,9 +4708,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4979,9 +4979,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4999,7 +4999,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5304,9 +5304,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5326,12 +5326,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secure-proxy-manager-ui",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secure-proxy-manager-ui",
-      "version": "3.11.1",
+      "version": "3.11.2",
       "dependencies": {
         "@tanstack/react-query": "^5.95.0",
         "axios": "^1.16.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.11.1",
+  "version": "3.11.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Why
Every PR was red on **Security scanning** + **Trivy CVE scan** because of UI advisories with no proportionate fix (react-router RSC CSRF, brace-expansion in the eslint devtree), forcing admin-bypass merges. Plus the VitePress **docs** lockfile carried its own high advisories.

## Allowlist infra
- **`scripts/npm-audit-gate.mjs`** — wraps `npm audit --json`, fails on HIGH/CRITICAL **except** advisories justified in **`scripts/npm-audit-allowlist.json`**, and prints ignored ones on every run (never silent). Replaces the bare `npm audit --audit-level=high` step. Verified: exit 0 with allowlist, 1 without.
- **`.trivyignore`** — same policy for the Trivy fs scan (native ignore).
- Allowlisted (non-applicable / dev-only, no clean fix, both tracked as follow-ups):
  - `GHSA-qwww-vcr4-c8h2` react-router RSC-mode CSRF — SPA uses client-side/data mode, not RSC; forward fix = react-router **v8 migration**.
  - `GHSA-mh99-v99m-4gvg` brace-expansion DoS — eslint devDependency subtree only, lint-time over trusted globs, no runtime artifact; forcing ≥5.0.8 breaks eslint's minimatch, so the only fix is **eslint@10** (breaking).

## docs deps
`npm audit fix` in `docs/`: **vite 6.4.2→6.4.3** (fixes fs.deny bypass + launch-editor NTLM, both Windows-dev-only) and **postcss 8.5.23**. docs now audits clean; VitePress build verified.

## Effect
Restores green required checks for normal PRs; closes Dependabot alerts #85/#86/#100. Alert #101 (react-router RSC) to be dismissed as not-applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)