### PR TITLE
chore(ui): bump node build image 20.19 → 24 LTS (retargets #175)

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,5 @@
 # Pin: node 20.19 alpine 3.21 (2025-04)
-FROM node:20.19-alpine3.21@sha256:eb0b81f6eb35ec5ecd1cab181801f93a6314127580b416e6e290363b724e1686 AS frontend-builder
+FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS frontend-builder
 WORKDIR /frontend
 COPY ./ui/package*.json ./
 RUN npm ci


### PR DESCRIPTION
Retargets Dependabot #175 (which proposed **node 25**, non-LTS) to **node 24 LTS**. Frontend-builder stage only — node isn't in the runtime image. Pinned by multi-arch digest. Closes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)