### PR TITLE
fix(ui): re-enable react-hooks/set-state-in-effect with vetted exceptions

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -19,14 +19,5 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
-    rules: {
-      // Opt out of react-hooks 7.1's new (React-Compiler-era) rule for now.
-      // Our two effects that trip it are intentional: seeding editable local
-      // state from an async query (the Settings form) and seeding a WebSocket
-      // log buffer from the initial fetch. Adopting the rule means refactoring
-      // core UI with real regression risk — tracked as a follow-up, not part of
-      // the eslint 9->10 bump.
-      'react-hooks/set-state-in-effect': 'off',
-    },
   },
 ])

--- a/ui/src/pages/Logs.tsx
+++ b/ui/src/pages/Logs.tsx
@@ -21,11 +21,13 @@ export function Logs() {
   });
 
   useEffect(() => {
-    if (data?.data) {
-      setRealtimeLogs(data.data.slice(0, 200));
-    } else if (data?.logs) {
-      setRealtimeLogs(data.logs.slice(0, 200));
-    }
+    // Seed the realtime buffer from the initial fetch; the WebSocket then
+    // prepends live entries onto it. This deliberately mirrors async query data
+    // into local state (the buffer is a merge of fetch + WS and is reset on
+    // clear), which is exactly what set-state-in-effect flags — vetted exception.
+    const initial = data?.data ?? data?.logs;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (initial) setRealtimeLogs(initial.slice(0, 200));
   }, [data]);
 
   // Setup WebSocket connection for real-time logs with auto-reconnect

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -93,6 +93,11 @@ export function Settings() {
       // API returns [{setting_name, setting_value}, ...] — convert to {key: value} map
       const map: Record<string, string> = {};
       settingsData.forEach((s) => { map[s.setting_name] = s.setting_value; });
+      // Seeding an editable form's local state from the fetched settings is a
+      // deliberate mirror of async query data into state — exactly what
+      // set-state-in-effect flags. Vetted exception (a full key-reset refactor
+      // isn't warranted here). See issue #192.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setFormData(map);
     }
   }, [settingsData, loading, error]);


### PR DESCRIPTION
Closes #192. Re-enables the rule disabled in #190; the two intentional effects (Logs realtime buffer, Settings form seed) get targeted, justified disables so the rule guards all new code. lint clean, build + 137 tests pass.