### PR TITLE
fix(waf): persistent writable volume for the traffic feature log (#112)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,13 @@ PROXY_IP=
 # Anomaly score threshold (lower = stricter). Default: 10
 # WAF_BLOCK_THRESHOLD=10
 
+# Where the WAF writes its per-request traffic feature log (JSONL). Defaults to
+# the dedicated persistent volume (/var/lib/waf) so it survives restarts while
+# /data stays read-only. If the path is unwritable the WAF falls back to a
+# /tmp tmpfs (ephemeral) and, failing that, disables the log (see the
+# waf_trafficlog_enabled metric). See issue #112.
+# WAF_TRAFFIC_LOG_PATH=/var/lib/waf/waf_traffic.jsonl
+
 # Comma-separated categories to disable (e.g. DEBUG_LEAK,RESPONSE_ANOMALY)
 WAF_DISABLED_CATEGORIES=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,14 @@ services:
     volumes:
       - ./config:/config:ro
       - ./data:/data:ro
+      # Dedicated writable volume for the traffic feature log, so it persists
+      # across restarts and stays off the memory-backed /tmp tmpfs while /data
+      # stays read-only (issue #112).
+      - waf-traffic:/var/lib/waf
     environment:
       - BASIC_AUTH_USERNAME=${BASIC_AUTH_USERNAME}
       - BASIC_AUTH_PASSWORD=${BASIC_AUTH_PASSWORD}
+      - WAF_TRAFFIC_LOG_PATH=${WAF_TRAFFIC_LOG_PATH:-/var/lib/waf/waf_traffic.jsonl}
       - WAF_BLOCK_THRESHOLD=${WAF_BLOCK_THRESHOLD:-10}
       # Heuristic engine toggles (1=on, 0=off)
       - WAF_H_ENTROPY=${WAF_H_ENTROPY:-1}
@@ -334,6 +339,8 @@ networks:
     internal: true
 
 volumes:
+  waf-traffic:
+    driver: local
   squid-cache:
     driver: local
   tailscale-data:

--- a/waf-go/Dockerfile
+++ b/waf-go/Dockerfile
@@ -17,6 +17,13 @@ WORKDIR /app
 COPY --from=builder /app/waf-server .
 RUN chown waf:waf /app/waf-server
 
+# Persistent, writable sink for the traffic feature log (issue #112). Created
+# owned by waf so that when the empty `waf-traffic` named volume is first mounted
+# here, Docker seeds it with waf:waf ownership — writable by the non-root process
+# even under a read_only root filesystem, and surviving restarts (unlike the
+# /tmp tmpfs fallback). WAF_TRAFFIC_LOG_PATH points the logger at this dir.
+RUN mkdir -p /var/lib/waf && chown waf:waf /var/lib/waf
+
 USER waf
 
 EXPOSE 1344


### PR DESCRIPTION
Closes #112. /data is read-only, so the traffic JSONL fell back to the ephemeral, memory-backed /tmp tmpfs. Adds a dedicated `waf-traffic:/var/lib/waf` volume (owned by the non-root waf user via Dockerfile mkdir+chown, writable under read_only root) and points WAF_TRAFFIC_LOG_PATH at it. No Go change — the logger already supports the env + fallback. The feature vector + correlation event_id now persist across restarts.