### PR TITLE
feat: wire WAF heuristic toggles end-to-end (runtime, no restart) (#102)

### DIFF
--- a/backend-go/internal/handlers/settings.go
+++ b/backend-go/internal/handlers/settings.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"net/http"
@@ -155,6 +157,10 @@ func (h *SettingsHandlers) BulkUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Push heuristic toggles to the running WAF so they take effect immediately —
+	// the WAF otherwise only reads WAF_H_* env at startup (issue #102).
+	h.pushHeuristicsToWAF(r.Context(), body)
+
 	// Toggle files — Squid reads these at container startup.
 	toggles := []struct {
 		key  string
@@ -239,6 +245,44 @@ func (h *SettingsHandlers) BulkUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "success", "message": "Settings updated"})
+}
+
+// heuristicSettingKeys are the WAF heuristic toggles that must be propagated to
+// the running WAF, which otherwise only reads WAF_H_* env at startup. Keep in
+// sync with the WAF's heuristicToggles map (waf-go/heuristics.go).
+var heuristicSettingKeys = map[string]bool{
+	"waf_h_entropy":   true,
+	"waf_h_beaconing": true,
+	"waf_h_pii":       true,
+	"waf_h_sharding":  true,
+	"waf_h_ghosting":  true,
+	"waf_h_sequence":  true,
+}
+
+// pushHeuristicsToWAF propagates any heuristic toggles in the just-saved settings
+// to the WAF's runtime config (POST /heuristics/toggle). Best-effort: the DB is
+// the source of truth, so a WAF hiccup is logged but never fails the save — the
+// value still applies on the WAF's next restart via WAF_H_* env, and re-saving
+// re-pushes.
+func (h *SettingsHandlers) pushHeuristicsToWAF(ctx context.Context, body map[string]string) {
+	for key, val := range body {
+		if !heuristicSettingKeys[key] {
+			continue
+		}
+		payload, err := json.Marshal(map[string]any{"heuristic": key, "enabled": val == "true"})
+		if err != nil {
+			continue
+		}
+		resp, err := wafPostBreaker(ctx, h.cfg, "/heuristics/toggle", "application/json", bytes.NewReader(payload))
+		if err != nil {
+			log.Warn().Str("key", key).Err(err).Msg("failed to push heuristic toggle to WAF — applies on WAF restart")
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			log.Warn().Str("key", key).Int("status", resp.StatusCode).Msg("WAF rejected heuristic toggle")
+		}
+		resp.Body.Close() //nolint:errcheck
+	}
 }
 
 // writeSquidSettingsEnv writes a shell-sourceable env file to /config/squid_settings.env

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -724,7 +724,7 @@ export function Settings() {
             {/* WAF Heuristics toggles */}
             <div className="p-4 border border-border/50 rounded-lg bg-secondary/40">
               <label className="text-sm font-medium mb-2 block">WAF Behavioral Heuristics</label>
-              <p className="text-xs text-muted-foreground mb-3">Advanced stateful anomaly detection. Saved here and applied to the WAF on its next container restart (via the matching WAF_H_* configuration).</p>
+              <p className="text-xs text-muted-foreground mb-3">Advanced stateful anomaly detection. Applied to the running WAF immediately on save — no container restart needed.</p>
               <div className="grid grid-cols-2 gap-2">
                 {[
                   { key: 'waf_h_entropy', label: 'Entropy Detection', desc: 'Block high-entropy payloads (encrypted/compressed = exfiltration)' },
@@ -732,6 +732,7 @@ export function Settings() {
                   { key: 'waf_h_pii', label: 'PII Leak Counter', desc: 'Count emails/CC/SSN in responses' },
                   { key: 'waf_h_sharding', label: 'Dest Sharding', desc: 'Block rapid multi-destination access' },
                   { key: 'waf_h_ghosting', label: 'Protocol Ghosting', desc: 'Detect SSH/ELF/PE in HTTP body' },
+                  { key: 'waf_h_sequence', label: 'Sequence Validation', desc: 'Detect impossible request sequences (off by default)' },
                 ].map((h) => (
                   <div key={h.key} className="flex items-center justify-between p-2 bg-secondary/20 rounded">
                     <div>

--- a/waf-go/heuristics.go
+++ b/waf-go/heuristics.go
@@ -39,10 +39,63 @@ type HeuristicResult struct {
 	Detail   string
 }
 
-var heuristicCfg HeuristicConfig
+// heuristicCfg is read on the request hot path (Check{Request,Response}Heuristics)
+// and mutated at runtime via the /heuristics/toggle mgmt endpoint, so every
+// access goes through heuristicCfgMu. Hot-path readers take ONE RLock snapshot
+// per call (loadHeuristicCfg) instead of locking per field.
+var (
+	heuristicCfg   HeuristicConfig
+	heuristicCfgMu sync.RWMutex
+)
+
+// loadHeuristicCfg returns a consistent copy of the current heuristic config.
+func loadHeuristicCfg() HeuristicConfig {
+	heuristicCfgMu.RLock()
+	defer heuristicCfgMu.RUnlock()
+	return heuristicCfg
+}
+
+// heuristicToggles maps the DB/UI setting key to a pointer-setter on the config.
+// It is the single source of truth for which heuristics are runtime-toggleable
+// and how their `waf_h_*` key maps to the struct field.
+var heuristicToggles = map[string]func(*HeuristicConfig, bool){
+	"waf_h_entropy":   func(c *HeuristicConfig, v bool) { c.EntropyThreshold = v },
+	"waf_h_beaconing": func(c *HeuristicConfig, v bool) { c.BeaconingDetection = v },
+	"waf_h_pii":       func(c *HeuristicConfig, v bool) { c.PIICounter = v },
+	"waf_h_sharding":  func(c *HeuristicConfig, v bool) { c.DestinationSharding = v },
+	"waf_h_ghosting":  func(c *HeuristicConfig, v bool) { c.ProtocolGhosting = v },
+	"waf_h_sequence":  func(c *HeuristicConfig, v bool) { c.SequenceValidation = v },
+}
+
+// heuristicStates returns the current on/off state keyed by the DB/UI `waf_h_*`
+// key (the read counterpart of heuristicToggles).
+func heuristicStates() map[string]bool {
+	cfg := loadHeuristicCfg()
+	return map[string]bool{
+		"waf_h_entropy":   cfg.EntropyThreshold,
+		"waf_h_beaconing": cfg.BeaconingDetection,
+		"waf_h_pii":       cfg.PIICounter,
+		"waf_h_sharding":  cfg.DestinationSharding,
+		"waf_h_ghosting":  cfg.ProtocolGhosting,
+		"waf_h_sequence":  cfg.SequenceValidation,
+	}
+}
+
+// setHeuristicEnabled flips one heuristic at runtime under the write lock.
+// Returns false if the key is not a known heuristic toggle.
+func setHeuristicEnabled(key string, enabled bool) bool {
+	apply, ok := heuristicToggles[key]
+	if !ok {
+		return false
+	}
+	heuristicCfgMu.Lock()
+	apply(&heuristicCfg, enabled)
+	heuristicCfgMu.Unlock()
+	return true
+}
 
 func initHeuristics() {
-	heuristicCfg = HeuristicConfig{
+	cfg := HeuristicConfig{
 		EntropyThreshold:     envBool("WAF_H_ENTROPY", true),
 		EntropyMax:           envFloat("WAF_H_ENTROPY_MAX", 7.5),
 		BeaconingDetection:   envBool("WAF_H_BEACONING", true),
@@ -55,25 +108,18 @@ func initHeuristics() {
 		ProtocolGhosting:     envBool("WAF_H_GHOSTING", true),
 		SequenceValidation:   envBool("WAF_H_SEQUENCE", false), // Off by default (needs tuning)
 	}
+	heuristicCfgMu.Lock()
+	heuristicCfg = cfg
+	heuristicCfgMu.Unlock()
 
 	enabled := 0
-	if heuristicCfg.EntropyThreshold {
-		enabled++
-	}
-	if heuristicCfg.BeaconingDetection {
-		enabled++
-	}
-	if heuristicCfg.PIICounter {
-		enabled++
-	}
-	if heuristicCfg.DestinationSharding {
-		enabled++
-	}
-	if heuristicCfg.ProtocolGhosting {
-		enabled++
-	}
-	if heuristicCfg.SequenceValidation {
-		enabled++
+	for _, on := range []bool{
+		cfg.EntropyThreshold, cfg.BeaconingDetection, cfg.PIICounter,
+		cfg.DestinationSharding, cfg.ProtocolGhosting, cfg.SequenceValidation,
+	} {
+		if on {
+			enabled++
+		}
 	}
 	log.Printf("Heuristic engine: %d/6 rules enabled\n", enabled)
 }
@@ -137,6 +183,9 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 	var results []HeuristicResult
 	totalScore := 0
 
+	// One consistent snapshot of the (runtime-mutable) config for this request.
+	cfg := loadHeuristicCfg()
+
 	cs := getClientState(clientIP)
 	now := time.Now()
 
@@ -146,8 +195,8 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 	// H2: trim old beaconing entries
 	var validTimes []time.Time
 	var validSizes []int
-	if heuristicCfg.BeaconingDetection {
-		window := time.Duration(heuristicCfg.BeaconingWindow) * time.Second
+	if cfg.BeaconingDetection {
+		window := time.Duration(cfg.BeaconingWindow) * time.Second
 		cutoff := now.Add(-window)
 		for i, t := range cs.reqTimes {
 			if t.After(cutoff) {
@@ -170,7 +219,7 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 
 	// H4: clean old dests, record new
 	var destCount int
-	if heuristicCfg.DestinationSharding {
+	if cfg.DestinationSharding {
 		for d, t := range cs.dests {
 			if now.Sub(t) > 60*time.Second {
 				delete(cs.dests, d)
@@ -183,7 +232,7 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 
 	// H7: snapshot last method/path
 	var prevMethod, prevPath string
-	if heuristicCfg.SequenceValidation {
+	if cfg.SequenceValidation {
 		prevMethod = cs.lastMethod
 		prevPath = cs.lastPath
 		cs.lastMethod = method
@@ -193,23 +242,23 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 	// ── End single-lock section ────────────────────────────────────────
 
 	// ── H1: Entropy Thresholding ────────────────────────────────────────
-	if heuristicCfg.EntropyThreshold {
-		if bodyEntropy > heuristicCfg.EntropyMax && bodySize > 256 {
+	if cfg.EntropyThreshold {
+		if bodyEntropy > cfg.EntropyMax && bodySize > 256 {
 			r := HeuristicResult{
 				ID:       "H1-ENTROPY",
 				Category: "HEURISTIC_ENTROPY",
 				Score:    6, // probabilistic: below blockThreshold, needs corroboration
-				Detail:   fmt.Sprintf("body entropy %.2f > %.1f (size=%d)", bodyEntropy, heuristicCfg.EntropyMax, bodySize),
+				Detail:   fmt.Sprintf("body entropy %.2f > %.1f (size=%d)", bodyEntropy, cfg.EntropyMax, bodySize),
 			}
 			results = append(results, r)
 			totalScore += r.Score
 		}
-		if urlEntropy > heuristicCfg.EntropyMax {
+		if urlEntropy > cfg.EntropyMax {
 			r := HeuristicResult{
 				ID:       "H1-URL-ENTROPY",
 				Category: "HEURISTIC_ENTROPY",
 				Score:    7,
-				Detail:   fmt.Sprintf("URL entropy %.2f > %.1f", urlEntropy, heuristicCfg.EntropyMax),
+				Detail:   fmt.Sprintf("URL entropy %.2f > %.1f", urlEntropy, cfg.EntropyMax),
 			}
 			results = append(results, r)
 			totalScore += r.Score
@@ -217,15 +266,15 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 	}
 
 	// ── H2: Beaconing Detection ─────────────────────────────────────────
-	if heuristicCfg.BeaconingDetection {
-		if len(validTimes) >= heuristicCfg.BeaconingMinRequests {
+	if cfg.BeaconingDetection {
+		if len(validTimes) >= cfg.BeaconingMinRequests {
 			// Check for regular intervals (beaconing)
 			if isBeaconing(validTimes) && isUniformSize(validSizes) {
 				r := HeuristicResult{
 					ID:       "H2-BEACON",
 					Category: "HEURISTIC_BEACONING",
 					Score:    6, // probabilistic: below blockThreshold, needs corroboration
-					Detail:   fmt.Sprintf("regular interval pattern detected (%d reqs in %ds)", len(validTimes), heuristicCfg.BeaconingWindow),
+					Detail:   fmt.Sprintf("regular interval pattern detected (%d reqs in %ds)", len(validTimes), cfg.BeaconingWindow),
 				}
 				results = append(results, r)
 				totalScore += r.Score
@@ -234,13 +283,13 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 	}
 
 	// ── H4: Destination Sharding ────────────────────────────────────────
-	if heuristicCfg.DestinationSharding {
-		if destCount > heuristicCfg.ShardingMaxDests {
+	if cfg.DestinationSharding {
+		if destCount > cfg.ShardingMaxDests {
 			r := HeuristicResult{
 				ID:       "H4-SHARDING",
 				Category: "HEURISTIC_SHARDING",
 				Score:    6, // probabilistic: below blockThreshold, needs corroboration
-				Detail:   fmt.Sprintf("%d unique destinations in 60s (max=%d)", destCount, heuristicCfg.ShardingMaxDests),
+				Detail:   fmt.Sprintf("%d unique destinations in 60s (max=%d)", destCount, cfg.ShardingMaxDests),
 			}
 			results = append(results, r)
 			totalScore += r.Score
@@ -248,7 +297,7 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 	}
 
 	// ── H6: Protocol Ghosting ───────────────────────────────────────────
-	if heuristicCfg.ProtocolGhosting {
+	if cfg.ProtocolGhosting {
 		if ghost := detectProtocolGhosting(body); ghost != "" {
 			r := HeuristicResult{
 				ID:       "H6-GHOST",
@@ -262,7 +311,7 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 	}
 
 	// ── H7: Sequence Validation ─────────────────────────────────────────
-	if heuristicCfg.SequenceValidation {
+	if cfg.SequenceValidation {
 		if isInvalidSequence(prevMethod, prevPath, method, path) {
 			r := HeuristicResult{
 				ID:       "H7-SEQUENCE",
@@ -280,7 +329,8 @@ func CheckRequestHeuristics(clientIP, method, host, path, body string, bodySize 
 
 // CheckResponseHeuristics checks response body for PII leaks (H3).
 func CheckResponseHeuristics(body string) ([]HeuristicResult, int) {
-	if !heuristicCfg.PIICounter || len(body) == 0 {
+	cfg := loadHeuristicCfg()
+	if !cfg.PIICounter || len(body) == 0 {
 		return nil, 0
 	}
 
@@ -292,12 +342,12 @@ func CheckResponseHeuristics(body string) ([]HeuristicResult, int) {
 	// SSN
 	count += len(reSSN.FindAllString(body, -1))
 
-	if count > heuristicCfg.PIIMaxPerResponse {
+	if count > cfg.PIIMaxPerResponse {
 		r := HeuristicResult{
 			ID:       "H3-PII",
 			Category: "HEURISTIC_PII_LEAK",
 			Score:    10,
-			Detail:   fmt.Sprintf("%d PII items in response (max=%d)", count, heuristicCfg.PIIMaxPerResponse),
+			Detail:   fmt.Sprintf("%d PII items in response (max=%d)", count, cfg.PIIMaxPerResponse),
 		}
 		return []HeuristicResult{r}, r.Score
 	}

--- a/waf-go/heuristics_toggle_test.go
+++ b/waf-go/heuristics_toggle_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Runtime toggle changes engine behaviour without re-init (the core of #102).
+func TestSetHeuristicEnabledRuntime(t *testing.T) {
+	initHeuristics() // PIICounter on, max 5 by default
+
+	body := strings.Repeat("a@b.com, ", 6) // 6 emails > max → should fire
+	if _, score := CheckResponseHeuristics(body); score == 0 {
+		t.Fatal("expected PII heuristic to fire with PIICounter on")
+	}
+
+	if ok := setHeuristicEnabled("waf_h_pii", false); !ok {
+		t.Fatal("setHeuristicEnabled(waf_h_pii) returned false for a known key")
+	}
+	if _, score := CheckResponseHeuristics(body); score != 0 {
+		t.Fatalf("expected no PII score after toggling waf_h_pii off, got %d", score)
+	}
+	if heuristicStates()["waf_h_pii"] {
+		t.Fatal("heuristicStates still reports waf_h_pii enabled after toggle off")
+	}
+
+	if setHeuristicEnabled("waf_h_nonexistent", true) {
+		t.Fatal("setHeuristicEnabled accepted an unknown key")
+	}
+}
+
+func TestHeuristicsToggleHandler(t *testing.T) {
+	initHeuristics()
+	h := &MgmtHandlers{}
+
+	post := func(bodyJSON string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/heuristics/toggle", strings.NewReader(bodyJSON))
+		rec := httptest.NewRecorder()
+		h.HeuristicsToggleHandler(rec, req)
+		return rec
+	}
+
+	// Valid toggle off.
+	if rec := post(`{"heuristic":"waf_h_ghosting","enabled":false}`); rec.Code != http.StatusOK {
+		t.Fatalf("valid toggle: got %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if heuristicStates()["waf_h_ghosting"] {
+		t.Fatal("waf_h_ghosting still enabled after toggle-off via handler")
+	}
+	// Back on.
+	if rec := post(`{"heuristic":"waf_h_ghosting","enabled":true}`); rec.Code != http.StatusOK {
+		t.Fatalf("re-enable: got %d, want 200", rec.Code)
+	}
+	if !heuristicStates()["waf_h_ghosting"] {
+		t.Fatal("waf_h_ghosting not re-enabled via handler")
+	}
+	// Unknown heuristic → 400.
+	if rec := post(`{"heuristic":"waf_h_bogus","enabled":true}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown heuristic: got %d, want 400", rec.Code)
+	}
+	// Missing heuristic → 400.
+	if rec := post(`{"enabled":true}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing heuristic: got %d, want 400", rec.Code)
+	}
+	// Wrong method → 405.
+	req := httptest.NewRequest(http.MethodGet, "/heuristics/toggle", nil)
+	rec := httptest.NewRecorder()
+	h.HeuristicsToggleHandler(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET: got %d, want 405", rec.Code)
+	}
+}
+
+func TestHeuristicsHandlerReportsState(t *testing.T) {
+	initHeuristics()
+	setHeuristicEnabled("waf_h_sequence", true)
+	req := httptest.NewRequest(http.MethodGet, "/heuristics", nil)
+	rec := httptest.NewRecorder()
+	(&MgmtHandlers{}).HeuristicsHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", rec.Code)
+	}
+	var out struct {
+		Data map[string]bool `json:"data"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !out.Data["waf_h_sequence"] {
+		t.Fatalf("expected waf_h_sequence=true in state, got %+v", out.Data)
+	}
+}
+
+// Concurrent toggles + hot-path reads must be race-free (run with -race).
+func TestHeuristicCfgConcurrentAccess(t *testing.T) {
+	initHeuristics()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func(on bool) { defer wg.Done(); setHeuristicEnabled("waf_h_entropy", on) }(i%2 == 0)
+		go func() {
+			defer wg.Done()
+			_ = loadHeuristicCfg()
+			CheckResponseHeuristics("x@y.com")
+		}()
+	}
+	wg.Wait()
+}

--- a/waf-go/main.go
+++ b/waf-go/main.go
@@ -828,6 +828,8 @@ func main() {
 		healthMux.HandleFunc("/reset", mgmtAuthMiddleware(h.ResetHandler))
 		healthMux.HandleFunc("/categories", mgmtAuthMiddleware(h.CategoriesHandler))
 		healthMux.HandleFunc("/categories/toggle", mgmtAuthMiddleware(h.CategoriesToggleHandler))
+		healthMux.HandleFunc("/heuristics", mgmtAuthMiddleware(h.HeuristicsHandler))
+		healthMux.HandleFunc("/heuristics/toggle", mgmtAuthMiddleware(h.HeuristicsToggleHandler))
 
 		log.Printf("Starting health endpoint on :8080\n")
 		if err := http.ListenAndServe(":8080", healthMux); err != nil {
@@ -889,11 +891,12 @@ func (h *MgmtHandlers) MetricsHandler(w http.ResponseWriter, r *http.Request) {
 	disabledCatCount := len(disabledCats)
 	disabledCatMu.RUnlock()
 
+	hcfg := loadHeuristicCfg()
 	heuristicsEnabled := 0
 	for _, on := range []bool{
-		heuristicCfg.EntropyThreshold, heuristicCfg.BeaconingDetection,
-		heuristicCfg.PIICounter, heuristicCfg.DestinationSharding,
-		heuristicCfg.ProtocolGhosting, heuristicCfg.SequenceValidation,
+		hcfg.EntropyThreshold, hcfg.BeaconingDetection,
+		hcfg.PIICounter, hcfg.DestinationSharding,
+		hcfg.ProtocolGhosting, hcfg.SequenceValidation,
 	} {
 		if on {
 			heuristicsEnabled++
@@ -995,8 +998,9 @@ func (h *MgmtHandlers) HealthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+	hcfg := loadHeuristicCfg()
 	hEnabled := 0
-	for _, on := range []bool{heuristicCfg.EntropyThreshold, heuristicCfg.BeaconingDetection, heuristicCfg.PIICounter, heuristicCfg.DestinationSharding, heuristicCfg.ProtocolGhosting, heuristicCfg.SequenceValidation} {
+	for _, on := range []bool{hcfg.EntropyThreshold, hcfg.BeaconingDetection, hcfg.PIICounter, hcfg.DestinationSharding, hcfg.ProtocolGhosting, hcfg.SequenceValidation} {
 		if on {
 			hEnabled++
 		}
@@ -1083,4 +1087,46 @@ func (h *MgmtHandlers) CategoriesToggleHandler(w http.ResponseWriter, r *http.Re
 	log.Printf("Category %s: enabled=%v\n", req.Category, req.Enabled)
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, `{"status":"ok","category":"%s","enabled":%v}`, req.Category, req.Enabled)
+}
+
+// HeuristicsHandler returns the current on/off state of each heuristic, keyed by
+// its `waf_h_*` setting key — lets the backend reconcile DB settings with the
+// live engine state.
+func (h *MgmtHandlers) HeuristicsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	if err := json.NewEncoder(w).Encode(map[string]any{"status": "ok", "data": heuristicStates()}); err != nil {
+		log.Printf("HeuristicsHandler encode error: %v\n", err)
+	}
+}
+
+// HeuristicsToggleHandler flips one heuristic at runtime (mirrors
+// CategoriesToggleHandler). Heuristics contribute to the anomaly score, so a
+// toggle changes verdicts — bump the ISTag and drop the safe-cache so Squid and
+// the WAF stop serving pre-toggle decisions.
+func (h *MgmtHandlers) HeuristicsToggleHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "POST only", 405)
+		return
+	}
+	// Bound the body — this endpoint accepts a tiny JSON object; without a cap an
+	// authenticated caller could OOM the WAF by streaming into json.Decoder.
+	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
+	var req struct {
+		Heuristic string `json:"heuristic"`
+		Enabled   bool   `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Heuristic == "" {
+		http.Error(w, `{"error":"heuristic required"}`, 400)
+		return
+	}
+	if !setHeuristicEnabled(req.Heuristic, req.Enabled) {
+		http.Error(w, `{"error":"unknown heuristic"}`, 400)
+		return
+	}
+	atomic.AddUint64(&istagEpoch, 1)
+	safeCache.Invalidate()
+	log.Printf("Heuristic %s: enabled=%v\n", req.Heuristic, req.Enabled)
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"status":"ok","heuristic":"%s","enabled":%v}`, req.Heuristic, req.Enabled)
 }


### PR DESCRIPTION
Closes #102. Heuristic toggles were **dead UI** — the WAF only read `WAF_H_*` env at init, so flipping a switch wrote a DB row nothing consumed until a container recreate. Now they apply **live**.

## WAF (`waf-go`)
- `heuristicCfg` is now guarded by a `sync.RWMutex` (`heuristicCfgMu`), modelled on the existing `disabledCatMu` category pattern. Hot-path readers (`Check{Request,Response}Heuristics`) take **one RLock snapshot per request** (`loadHeuristicCfg`) rather than reading the global lock-free — this closes the data race a runtime mutation would otherwise introduce, with no per-field locking on the hot path.
- `setHeuristicEnabled` + `heuristicToggles`/`heuristicStates` map each `waf_h_*` key ↔ struct field.
- New mgmt endpoints (behind `mgmtAuth`, 4KB-bounded, mirroring `/categories/toggle`): **`POST /heuristics/toggle`** flips one heuristic and bumps the ISTag + invalidates the safe-cache (verdicts change → Squid must drop cached decisions); **`GET /heuristics`** reports current state.

## Backend (`backend-go`)
- `settings.go` `BulkUpdate` pushes any `waf_h_*` keys to `POST /heuristics/toggle` after commit via `wafPostBreaker` — **best-effort** (DB is source of truth; a WAF hiccup is logged, applies on next restart, and re-saving re-pushes).

## UI (`ui`)
- Settings copy no longer claims a restart is needed; exposes the 6th heuristic (`waf_h_sequence`) the engine + backend already support.

## Tests
Runtime toggle changes behaviour (PII fires then stops), the HTTP handler (200 / 400 unknown / 400 missing / 405), the GET state endpoint, and **concurrent toggle+read under `-race`**. Full `waf-go` suite green under `-race`; backend + UI (137) green; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)