### PR TITLE
feat(ui): react-router v7 → v8; empty the CVE allowlist + release v3.11.3 (#191)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,9 +1,6 @@
 # Trivy vulnerability allowlist. ONLY for advisories that are non-applicable or
 # dev-only with no proportionate fix; every entry needs a justification.
 # Keep in sync with scripts/npm-audit-allowlist.json.
-
-# react-router — RSC Mode CSRF. NOT APPLICABLE: this SPA uses react-router-dom in
-# client-side/data mode, not RSC framework mode, so the vulnerable RSC action path
-# is never mounted. No forward fix for react-router-dom exists (no 8.x); the only
-# remediation is a react-router v7->v8 migration. Tracked follow-up: migrate to v8.
-GHSA-qwww-vcr4-c8h2
+#
+# Currently EMPTY — the react-router RSC-mode CSRF exception (GHSA-qwww-vcr4-c8h2)
+# was retired by the react-router v8 migration (#191).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.3] - 2026-08-02
+
+### Changed
+
+- **React Router upgraded v7 → v8** (`react-router@8.3.0`; the `react-router-dom`
+  package is dropped in v8, so all imports move to `react-router`). This clears
+  **GHSA-qwww-vcr4-c8h2** (RSC-mode CSRF, fixed in 8.3.0) — the last remaining
+  entry in the CVE-audit allowlist. `scripts/npm-audit-allowlist.json` and
+  `.trivyignore` are now empty: the `npm audit` + Trivy gates pass with **zero**
+  standing exceptions.
+
+### Also
+
+- WAF heuristic toggles are now wired end-to-end (runtime, no container restart)
+  — see [#102].
+
+[#102]: https://github.com/fabriziosalmi/secure-proxy-manager/issues/102
+
 ## [3.11.2] - 2026-07-25
 
 ### Security

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.11.2"
+const AppVersion = "3.11.3"

--- a/scripts/npm-audit-allowlist.json
+++ b/scripts/npm-audit-allowlist.json
@@ -1,6 +1,4 @@
 {
-  "_comment": "GHSA IDs that npm-audit-gate.mjs will NOT fail on. ONLY for advisories that are non-applicable or dev-only with no proportionate fix. Each MUST carry a justification and, ideally, a tracked follow-up. Runtime-reachable advisories must never be listed here — fix them.",
-  "allow": {
-    "GHSA-qwww-vcr4-c8h2": "react-router — RSC Mode CSRF. NOT APPLICABLE: this SPA uses react-router-dom in client-side/data mode, not RSC framework mode, so the vulnerable RSC action path is never mounted. No forward fix exists for react-router-dom (there is no 8.x of react-router-dom); the only remediation is a react-router v7->v8 migration. Tracked follow-up: migrate to react-router v8."
-  }
+  "_comment": "GHSA IDs that npm-audit-gate.mjs will NOT fail on. ONLY for advisories that are non-applicable or dev-only with no proportionate fix. Each MUST carry a justification and, ideally, a tracked follow-up. Runtime-reachable advisories must never be listed here — fix them. Currently EMPTY (the react-router RSC exception was retired by the v8 migration, #191).",
+  "allow": {}
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secure-proxy-manager-ui",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secure-proxy-manager-ui",
-      "version": "3.11.2",
+      "version": "3.11.3",
       "dependencies": {
         "@tanstack/react-query": "^5.95.0",
         "axios": "^1.16.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hot-toast": "^2.6.0",
-        "react-router-dom": "^7.16.0",
+        "react-router": "^8.3.0",
         "recharts": "^3.8.0",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
@@ -2736,18 +2736,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5024,24 +5017,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-hot-toast": {
@@ -5092,41 +5085,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -5365,12 +5341,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.11.2",
+  "version": "3.11.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hot-toast": "^2.6.0",
-    "react-router-dom": "^7.16.0",
+    "react-router": "^8.3.0",
     "recharts": "^3.8.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { Component, Suspense, lazy, useState, useEffect } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider, QueryCache } from '@tanstack/react-query';
 import toast, { Toaster } from 'react-hot-toast';
 import axios from 'axios';

--- a/ui/src/components/GlobalSearch.tsx
+++ b/ui/src/components/GlobalSearch.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Search, ArrowRight, Ban, Shield, List, Settings, LayoutDashboard, X } from 'lucide-react';
 import { api } from '../lib/api';
 import { useModal } from '../hooks/useModal';

--- a/ui/src/components/layout/Layout.tsx
+++ b/ui/src/components/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router';
 import { Sidebar } from './Sidebar';
 import { Menu, X } from 'lucide-react';
 

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router';
 import { LayoutDashboard, Ban, ShieldAlert, List, ScrollText, Users, Settings, Search, Command, LogOut, ArrowUpFromLine, Sun, Moon, SunMoon } from 'lucide-react';
 import { api } from '../../lib/api';
 import { useTheme } from '../ThemeProvider';

--- a/ui/src/test/helpers.tsx
+++ b/ui/src/test/helpers.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 import { render } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { ThemeProvider } from '../components/ThemeProvider'

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id) {
-          if (id.includes('node_modules/react-router-dom')) return 'vendor-react';
+          if (id.includes('node_modules/react-router')) return 'vendor-react';
           if (id.includes('node_modules/react-dom')) return 'vendor-react';
           if (id.includes('node_modules/react')) return 'vendor-react';
           if (id.includes('node_modules/recharts')) return 'vendor-charts';


### PR DESCRIPTION
Closes #191. Upgrades **React Router v7 → v8** (`react-router@8.3.0`; v8 drops the `react-router-dom` package — all imports move to `react-router`). 8.3.0 fixes **GHSA-qwww-vcr4-c8h2** (RSC-mode CSRF), the **last** entry in the audit allowlist.

- 5 import sites rewritten (App, GlobalSearch, Layout, Sidebar, test helpers); vite `manualChunks` updated.
- **`scripts/npm-audit-allowlist.json` and `.trivyignore` are now empty** — the npm-audit + Trivy gates pass with **zero standing exceptions**.
- Releases **v3.11.3** (also carries #102 heuristic wiring). version-sync green.

Verified locally: `npm audit` 0, Trivy 0 on all targets, tsc build + lint + 137 unit tests green, npm ci clean. Routes covered end-to-end by the Playwright e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)