### PR TITLE
ci: gate on the adversarial data-plane block-matrix (#200 Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,3 +273,18 @@ jobs:
       - name: Teardown
         if: always()
         run: docker compose -f docker-compose.test.yml down -v
+
+  # ── 11. Adversarial data-plane block-matrix (proxy + WAF/ICAP) ────────────
+  # Drives attacker traffic THROUGH the real forward proxy + WAF/ICAP in an
+  # isolated sandbox and gates on false negatives/positives (issue #200, Phase 1).
+  # run.sh prints the block-matrix + FP/FN report to the job log and tears the
+  # stack down on exit; a hard FN>0 or FP>0 fails the job. (To make it a hard
+  # merge gate, also add "Adversarial block-matrix (proxy + WAF)" to the
+  # branch's required status checks.)
+  adversarial:
+    name: Adversarial block-matrix (proxy + WAF)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Block-matrix through proxy + WAF/ICAP
+        run: bash tests/adversarial/run.sh


### PR DESCRIPTION
Wires the Phase 1 adversarial harness (#201) into CI as a job.

The new **Adversarial block-matrix (proxy + WAF)** job runs `tests/adversarial/run.sh` on `ubuntu-latest`: it stands up the isolated sandbox, drives the corpus through the real proxy + WAF/ICAP, prints the block-matrix + FP/FN report to the job log, tears the stack down, and **fails on any hard FN (malicious allowed) or FP (benign blocked)**.

- No new pinned action introduced — `run.sh` prints the report to the log, so the matrix is visible directly in the job output.
- Not yet a *required* status check; flip it on in branch protection once it has a green track record on CI.

Closes the "wire Phase 1 into CI" follow-up from #200. Later phases (API attacker / bench / resilience) remain tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)