### PR TITLE
test(adversarial): API attacker plane — backend auth boundary (#200 Phase 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ clean:
 	docker compose down -v --remove-orphans
 	@echo "⚠️  Data in ./data/ preserved. Remove manually if needed."
 
-# Adversarial e2e block-matrix: drive attacker traffic through the real proxy +
-# WAF/ICAP in an isolated sandbox and gate on false negatives/positives (#200).
+# Adversarial e2e: drive attacker traffic against the real proxy + WAF/ICAP
+# (block-matrix) and the backend auth boundary (API attacker) in an isolated
+# sandbox; gate on false negatives/positives and auth bypasses (#200).
 adversarial:
 	bash tests/adversarial/run.sh

--- a/tests/adversarial/README.md
+++ b/tests/adversarial/README.md
@@ -1,16 +1,23 @@
-# Adversarial e2e harness — Phase 1: data-plane block-matrix
+# Adversarial e2e harness (proxy + WAF data plane, backend API)
 
-Drives traffic **through the real forward proxy + WAF/ICAP** like a client /
-attacker and measures block/allow correctness. This is the data-plane
-counterpart to the UI Playwright suite and the API/UI-only
+Drives attacker-style traffic against the running product in an isolated
+sandbox and gates on security regressions. Two planes:
+
+- **Plane 1 — data-plane block-matrix.** Traffic **through the real forward
+  proxy + WAF/ICAP**; measures block/allow correctness (FP/FN).
+- **Plane 2 — API attacker.** Hits the **backend's auth boundary directly**
+  (auth-bypass, forged/tampered JWTs, login SQLi, rate-limit).
+
+This is the counterpart to the UI Playwright suite and the API/UI-only
 `docker-compose.test.yml` (which deliberately excludes proxy + WAF).
 
 Tracks issue [#200](https://github.com/fabriziosalmi/secure-proxy-manager/issues/200).
 
 ```
-attacker ──http_proxy──▶ proxy (Squid) ──ICAP──▶ waf   (REQMOD / RESPMOD)
-                              │  resolves via dns (dnsmasq)
-                              └──────────────▶ mock-upstream (controlled)
+plane 1:  attacker ──http_proxy──▶ proxy (Squid) ──ICAP──▶ waf   (REQMOD / RESPMOD)
+                                        │  resolves via dns (dnsmasq)
+                                        └──────────────▶ mock-upstream (controlled)
+plane 2:  attacker ─────────────────────────────────────▶ backend (Go API, direct)
 ```
 
 ## Run
@@ -19,10 +26,9 @@ attacker ──http_proxy──▶ proxy (Squid) ──ICAP──▶ waf   (REQM
 make adversarial          # or: bash tests/adversarial/run.sh
 ```
 
-The run builds the sandbox, sends every corpus case through the proxy, prints a
-**block-matrix + FP/FN report**, and tears the stack down. Exit code is the CI
-gate: **non-zero if any hard-gate case is a false negative (malicious allowed)
-or false positive (benign blocked)**.
+The run builds the sandbox, executes both planes, prints their reports, and
+tears the stack down. Exit code is the CI gate: **non-zero if plane 1 has a hard
+false negative/positive, or plane 2 has a hard auth/authorization regression.**
 
 Useful env:
 
@@ -72,8 +78,26 @@ single card is a corroborating signal, score 2 < 10, so it correctly passes).
 
 Extend it "as attackers": add cases, re-run with `NO_BUILD=1`, watch FN/FP.
 
+### Plane 2 — API attacker
+
+[`api-corpus.json`](api-corpus.json) — hits the backend directly:
+
+| field | meaning |
+|---|---|
+| `auth` | `none` \| `basic` \| `bearer_valid` \| `bearer_bad` \| `bearer_alg_none` \| `bearer_tampered` |
+| `expect` | `unauthorized` (401/403) \| `ok` (2xx control) \| `ratelimited` (burst → 429) |
+| `gate` | `hard` \| `soft` |
+
+Covers: auth-bypass on protected endpoints (status, settings, audit-log,
+database export/reset, change-password), forged JWTs (**alg=none** confusion,
+mutated signature, garbage), **login SQL-injection**, wrong-password, per-IP
+**rate-limit** enforcement, plus control cases proving legitimate Basic/JWT
+access still works. A protected endpoint returning 2xx unauthenticated is a
+**bypass** and fails the gate.
+
 ## Roadmap (later phases, see #200)
 
-- **Phase 2** — API attacker (JWT tampering, auth-bypass, IDOR) via nuclei / ZAP.
 - **Phase 3** — bench/latency (k6/vegeta): p50/p95, ICAP overhead, regression gate.
 - **Phase 4** — resilience: kill/restart waf/dns hot; self-heal + fail-closed hold.
+- Optional Phase 2b — templated scans (nuclei / ZAP baseline) layered on the
+  same sandbox.

--- a/tests/adversarial/api-corpus.json
+++ b/tests/adversarial/api-corpus.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "health-public",
+    "desc": "Public health endpoint is reachable (control: backend is up)",
+    "method": "GET", "path": "/api/health", "auth": "none",
+    "expect": "ok", "gate": "hard"
+  },
+  {
+    "id": "login-valid",
+    "desc": "Correct credentials issue a token (control: legit login works)",
+    "method": "POST", "path": "/api/auth/login", "auth": "none",
+    "content_type": "application/json",
+    "body": "{\"username\":\"testadmin\",\"password\":\"TestP@ss123!\"}",
+    "expect": "ok", "gate": "hard"
+  },
+  {
+    "id": "status-basic-valid",
+    "desc": "Valid Basic-Auth reaches a protected endpoint (control)",
+    "method": "GET", "path": "/api/status", "auth": "basic",
+    "expect": "ok", "gate": "hard"
+  },
+  {
+    "id": "status-bearer-valid",
+    "desc": "Valid JWT (from login) reaches a protected endpoint (control)",
+    "method": "GET", "path": "/api/status", "auth": "bearer_valid",
+    "expect": "ok", "gate": "hard"
+  },
+
+  {
+    "id": "status-noauth",
+    "desc": "Protected endpoint must reject unauthenticated access",
+    "method": "GET", "path": "/api/status", "auth": "none",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "settings-noauth",
+    "desc": "Settings must not be readable unauthenticated",
+    "method": "GET", "path": "/api/settings", "auth": "none",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "auditlog-noauth",
+    "desc": "Audit log must not be readable unauthenticated",
+    "method": "GET", "path": "/api/audit-log", "auth": "none",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "db-export-noauth",
+    "desc": "Database export (sensitive) must not be reachable unauthenticated",
+    "method": "GET", "path": "/api/database/export", "auth": "none",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "ratelimits-noauth",
+    "desc": "Security rate-limit admin must not be readable unauthenticated",
+    "method": "GET", "path": "/api/security/rate-limits", "auth": "none",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "changepw-noauth",
+    "desc": "Change-password must reject unauthenticated calls",
+    "method": "POST", "path": "/api/change-password", "auth": "none",
+    "content_type": "application/json",
+    "body": "{\"current_password\":\"x\",\"new_password\":\"Whatever1!\"}",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "dbreset-noauth",
+    "desc": "Destructive database reset must reject unauthenticated calls",
+    "method": "POST", "path": "/api/database/reset", "auth": "none",
+    "expect": "unauthorized", "gate": "hard"
+  },
+
+  {
+    "id": "bearer-garbage",
+    "desc": "Garbage bearer token is rejected",
+    "method": "GET", "path": "/api/status", "auth": "bearer_bad",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "bearer-alg-none",
+    "desc": "Forged alg=none JWT claiming admin must be rejected (alg confusion)",
+    "method": "GET", "path": "/api/status", "auth": "bearer_alg_none",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "bearer-tampered",
+    "desc": "Valid JWT with a mutated signature must be rejected",
+    "method": "GET", "path": "/api/status", "auth": "bearer_tampered",
+    "expect": "unauthorized", "gate": "hard"
+  },
+
+  {
+    "id": "login-sqli-comment",
+    "desc": "SQL-injection in username must not bypass login",
+    "method": "POST", "path": "/api/auth/login", "auth": "none",
+    "content_type": "application/json",
+    "body": "{\"username\":\"admin'--\",\"password\":\"x\"}",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "login-sqli-or",
+    "desc": "SQL-injection tautology in username must not bypass login",
+    "method": "POST", "path": "/api/auth/login", "auth": "none",
+    "content_type": "application/json",
+    "body": "{\"username\":\"' OR '1'='1\",\"password\":\"' OR '1'='1\"}",
+    "expect": "unauthorized", "gate": "hard"
+  },
+  {
+    "id": "login-wrong-password",
+    "desc": "Correct user + wrong password is rejected",
+    "method": "POST", "path": "/api/auth/login", "auth": "none",
+    "content_type": "application/json",
+    "body": "{\"username\":\"testadmin\",\"password\":\"definitely-wrong\"}",
+    "expect": "unauthorized", "gate": "hard"
+  },
+
+  {
+    "id": "ratelimit-burst",
+    "desc": "A rapid burst from one IP must eventually be rate-limited (429)",
+    "method": "GET", "path": "/api/status", "auth": "none",
+    "expect": "ratelimited", "gate": "hard", "burst": 90
+  }
+]

--- a/tests/adversarial/attacker/Dockerfile
+++ b/tests/adversarial/attacker/Dockerfile
@@ -9,7 +9,11 @@ WORKDIR /adversarial
 # corpus is reachable. Baked-in defaults; run.sh bind-mounts the live versions
 # over these for fast iteration (edit corpus/driver, re-run, no rebuild).
 COPY attacker/attack.sh /adversarial/attack.sh
+COPY attacker/api-attack.sh /adversarial/api-attack.sh
 COPY corpus.json /adversarial/corpus.json
-RUN chmod +x /adversarial/attack.sh
+COPY api-corpus.json /adversarial/api-corpus.json
+RUN chmod +x /adversarial/attack.sh /adversarial/api-attack.sh
 
+# Default entrypoint runs plane 1 (block-matrix); run.sh also invokes the API
+# plane via `run --rm --entrypoint /adversarial/api-attack.sh`.
 ENTRYPOINT ["/adversarial/attack.sh"]

--- a/tests/adversarial/attacker/api-attack.sh
+++ b/tests/adversarial/attacker/api-attack.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# Adversarial API attacker (issue #200, Phase 2).
+#
+# Probes the backend's OWN auth/authorization boundary by hitting it DIRECTLY
+# (not through the proxy): auth-bypass on protected endpoints, forged/tampered
+# JWTs (alg=none confusion, mutated signature), SQL-injection in login, and
+# rate-limit enforcement. Control cases prove legitimate access still works.
+#
+# Verdict per case:
+#   expect=unauthorized  → PASS iff 401/403; a 2xx is a BYPASS (FAIL)
+#   expect=ok            → PASS iff 2xx     (control; a non-2xx = broken)
+#   expect=ratelimited   → PASS iff a rapid burst yields >=1 HTTP 429
+#
+# Exit code = CI gate: non-zero if any hard-gate case fails.
+set -uo pipefail
+
+API="${API:-http://backend:5000}"
+API_CORPUS="${API_CORPUS:-/adversarial/api-corpus.json}"
+API_USER="${API_USER:-testadmin}"
+API_PASS="${API_PASS:-TestP@ss123!}"
+REPORT_DIR="${REPORT_DIR:-/report}"
+
+mkdir -p "$REPORT_DIR"
+RESULTS="$(mktemp)"
+
+green() { printf '\033[32m%s\033[0m' "$1"; }
+red()   { printf '\033[31m%s\033[0m' "$1"; }
+
+b64url() { base64 -w0 2>/dev/null | tr '+/' '-_' | tr -d '='; }
+
+echo "── SPM adversarial API attacker ─────────────────────────────────────────"
+echo "   api=$API  corpus=$API_CORPUS"
+echo
+
+# ── Obtain a real JWT for the bearer_valid / bearer_tampered cases ────────────
+login_resp=$(curl -sS --max-time 15 -X POST -H 'Content-Type: application/json' \
+  --data "{\"username\":\"$API_USER\",\"password\":\"$API_PASS\"}" \
+  "$API/api/auth/login" 2>/dev/null || true)
+TOKEN=$(printf '%s' "$login_resp" | jq -r '.access_token // empty' 2>/dev/null)
+[ -n "$TOKEN" ] && echo "   (obtained a session token for control/tamper cases)" \
+                || echo "   (WARNING: login did not return a token — control cases will surface it)"
+
+# alg=none forgery claiming admin (unsigned).
+ALG_NONE_H=$(printf '%s' '{"alg":"none","typ":"JWT"}' | b64url)
+ALG_NONE_P=$(printf '%s' '{"sub":"admin","username":"admin","role":"admin","exp":9999999999}' | b64url)
+ALG_NONE_TOKEN="${ALG_NONE_H}.${ALG_NONE_P}."
+
+# Valid token with a mutated signature (guaranteed-invalid).
+TAMPERED_TOKEN=""
+if [ -n "$TOKEN" ]; then
+  sig="${TOKEN##*.}"; rest="${TOKEN%.*}"; last="${sig: -1}"
+  if [ "$last" = "A" ]; then repl="B"; else repl="A"; fi
+  TAMPERED_TOKEN="${rest}.${sig%?}${repl}"
+fi
+
+n=$(jq 'length' "$API_CORPUS")
+i=0
+while [ "$i" -lt "$n" ]; do
+  row=$(jq -c ".[$i]" "$API_CORPUS")
+  i=$((i + 1))
+
+  IFS=$'\t' read -r id method path auth expect gate ctype <<EOF
+$(jq -r '[.id,.method,.path,.auth,.expect,.gate,(.content_type//"")] | @tsv' <<<"$row")
+EOF
+  body=$(jq -r '.body // empty' <<<"$row")
+
+  if [ "$expect" = "ratelimited" ]; then
+    burst=$(jq -r '.burst // 90' <<<"$row")
+    # Fire the burst with real concurrency so the arrival rate exceeds the
+    # limiter's sustained rate (20/s) + burst (60), reliably tripping 429.
+    got429=$(seq 1 "$burst" | xargs -P 20 -I{} \
+      curl -sS -o /dev/null -w '%{http_code}\n' --max-time 10 "$API$path" 2>/dev/null \
+      | grep -c '^429$' || true)
+    [ "${got429:-0}" -ge 1 ] && verdict="PASS" || verdict="FAIL"
+    status="burst:${burst},429x${got429:-0}"
+  else
+    set -- -sS --max-time 15 -o /dev/null -w '%{http_code}' -X "$method"
+    case "$auth" in
+      basic)          set -- "$@" -u "$API_USER:$API_PASS" ;;
+      bearer_valid)   set -- "$@" -H "Authorization: Bearer $TOKEN" ;;
+      bearer_bad)     set -- "$@" -H "Authorization: Bearer garbage.garbage.garbage" ;;
+      bearer_alg_none)set -- "$@" -H "Authorization: Bearer $ALG_NONE_TOKEN" ;;
+      bearer_tampered)set -- "$@" -H "Authorization: Bearer $TAMPERED_TOKEN" ;;
+      none)           : ;;
+    esac
+    if [ -n "$body" ]; then
+      [ -n "$ctype" ] && set -- "$@" -H "Content-Type: $ctype"
+      set -- "$@" --data "$body"
+    fi
+    set -- "$@" "$API$path"
+    status=$(curl "$@" 2>/dev/null || echo "000")
+
+    case "$expect" in
+      ok)           { [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 300 ]; } && verdict="PASS" || verdict="FAIL" ;;
+      unauthorized) { [ "$status" = "401" ] || [ "$status" = "403" ]; } && verdict="PASS" || verdict="FAIL" ;;
+      *)            verdict="FAIL" ;;
+    esac
+  fi
+
+  jq -nc --arg id "$id" --arg method "$method" --arg path "$path" --arg auth "$auth" \
+        --arg expect "$expect" --arg gate "$gate" --arg status "$status" --arg verdict "$verdict" \
+        '{id:$id,method:$method,path:$path,auth:$auth,expect:$expect,gate:$gate,status:$status,verdict:$verdict}' \
+        >>"$RESULTS"
+
+  [ "$verdict" = "PASS" ] && tag=$(green PASS) || tag=$(red FAIL)
+  printf '  %-22s %-6s %-26s auth=%-15s expect=%-13s got=%-16s %b\n' \
+    "$id" "$method" "$path" "$auth" "$expect" "$status" "$tag"
+done
+
+# ── Aggregate ────────────────────────────────────────────────────────────────
+jq -s '.' "$RESULTS" >"$REPORT_DIR/api-results.json"
+
+summary=$(jq '{
+  total: length,
+  pass:  [.[]|select(.verdict=="PASS")]|length,
+  fail:  [.[]|select(.verdict=="FAIL")]|length,
+  hard_fail: [.[]|select(.verdict=="FAIL" and .gate=="hard")]|length,
+  bypasses: [.[]|select(.verdict=="FAIL" and .expect=="unauthorized")]|length
+}' "$REPORT_DIR/api-results.json")
+
+hard_fail=$(jq -r '.hard_fail' <<<"$summary")
+pass=$(jq -r '.pass' <<<"$summary"); fail=$(jq -r '.fail' <<<"$summary")
+total=$(jq -r '.total' <<<"$summary"); bypasses=$(jq -r '.bypasses' <<<"$summary")
+
+gate_pass=true
+[ "$hard_fail" -gt 0 ] && gate_pass=false
+
+{
+  echo "# Adversarial API-attacker report"
+  echo
+  echo "> SPM backend auth/authorization regression — attacker hits the API"
+  echo "> directly (issue #200, Phase 2)."
+  echo
+  echo "## Summary"
+  echo
+  echo "| Metric | Value |"
+  echo "|---|---|"
+  echo "| Cases | $total |"
+  echo "| Pass | $pass |"
+  echo "| **Fail** | $fail (hard: $hard_fail) |"
+  echo "| **Auth bypasses (unauthenticated 2xx)** | $bypasses |"
+  if $gate_pass; then echo "| **Gate** | ✅ PASS |"; else echo "| **Gate** | ❌ FAIL |"; fi
+  echo
+  echo "## Cases"
+  echo
+  echo "| Case | Method | Path | Auth | Expect | Status | Verdict |"
+  echo "|---|---|---|---|---|---|---|"
+  jq -r '.[] | "| \(.id) | \(.method) | \(.path) | \(.auth) | \(.expect) | \(.status) | \(.verdict) |"' \
+    "$REPORT_DIR/api-results.json"
+  echo
+  if [ "$fail" -gt 0 ]; then
+    echo "## Failures"
+    echo
+    jq -r '.[] | select(.verdict=="FAIL") |
+      "- **FAIL** `\(.id)` (\(.expect), gate=\(.gate)) — \(.method) \(.path) auth=\(.auth) → \(.status)"' \
+      "$REPORT_DIR/api-results.json"
+    echo
+  fi
+} >"$REPORT_DIR/api-report.md"
+
+jq -n --argjson summary "$summary" --argjson gate_pass "$($gate_pass && echo true || echo false)" \
+  --slurpfile results "$REPORT_DIR/api-results.json" \
+  '{gate_pass:$gate_pass, summary:$summary, results:$results[0]}' \
+  >"$REPORT_DIR/api-report.json"
+
+echo
+echo "── Summary ──────────────────────────────────────────────────────────────"
+printf '  cases=%s  pass=%s  fail=%s(hard %s)  bypasses=%s\n' \
+  "$total" "$pass" "$fail" "$hard_fail" "$bypasses"
+if $gate_pass; then
+  echo "  gate: $(green PASS)"; echo "  report: $REPORT_DIR/api-report.md"; exit 0
+else
+  echo "  gate: $(red FAIL) — auth/authorization regressions present"
+  echo "  report: $REPORT_DIR/api-report.md"; exit 1
+fi

--- a/tests/adversarial/docker-compose.adversarial.yml
+++ b/tests/adversarial/docker-compose.adversarial.yml
@@ -163,6 +163,31 @@ services:
           - upstream.test
     restart: "no"
 
+  # ── Backend API (Go) ───────────────────────────────────────────────────────
+  # Target for Phase 2 (API attacker): the attacker hits it DIRECTLY (not through
+  # the proxy) to probe the app's own auth/authorization boundary. Known creds so
+  # the driver can prove that legitimate access still works (control cases).
+  backend:
+    build: ../../backend-go
+    environment:
+      - BASIC_AUTH_USERNAME=testadmin
+      - BASIC_AUTH_PASSWORD=TestP@ss123!
+      - SECRET_KEY=adv-e2e-secret-not-for-production
+      - CORS_ALLOWED_ORIGINS=http://localhost:8011
+      - DATABASE_PATH=/data/secure_proxy_adv.db
+    volumes:
+      - adv-backend-config:/config
+      - adv-backend-data:/data
+    healthcheck:
+      test: ["CMD", "/server", "-healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+      start_period: 15s
+    networks:
+      - adv-edge
+    restart: "no"
+
   # ── Attacker ───────────────────────────────────────────────────────────────
   # Runs the corpus through the proxy, writes the block-matrix + FP/FN report to
   # ./report, and exits with the CI gate code (non-zero on hard FN/FP).
@@ -175,16 +200,25 @@ services:
         condition: service_healthy
       mock-upstream:
         condition: service_healthy
+      backend:
+        condition: service_healthy
     environment:
       - PROXY=http://proxy:3128
       - BASE=http://upstream.test
       - CORPUS=/adversarial/corpus.json
       - REPORT_DIR=/report
+      # Phase 2 (API attacker) — hit the backend directly.
+      - API=http://backend:5000
+      - API_CORPUS=/adversarial/api-corpus.json
+      - API_USER=testadmin
+      - API_PASS=TestP@ss123!
     volumes:
       # Bind-mounted for fast iteration: edit the corpus/driver and re-run with
       # no image rebuild.
       - ./attacker/attack.sh:/adversarial/attack.sh:ro
+      - ./attacker/api-attack.sh:/adversarial/api-attack.sh:ro
       - ./corpus.json:/adversarial/corpus.json:ro
+      - ./api-corpus.json:/adversarial/api-corpus.json:ro
       - ./report:/report
     networks:
       - adv-edge
@@ -201,7 +235,9 @@ networks:
         - subnet: 10.99.0.0/24
 
 volumes:
-  # Ephemeral /config and /data for waf + proxy — removed by `down -v`, keeping
-  # the working tree clean (no config/squid_version.txt etc.).
+  # Ephemeral /config and /data for waf + proxy + backend — removed by `down -v`,
+  # keeping the working tree clean (no config/squid_version.txt, no sqlite db).
   adv-config:
   adv-data:
+  adv-backend-config:
+  adv-backend-data:

--- a/tests/adversarial/run.sh
+++ b/tests/adversarial/run.sh
@@ -51,33 +51,45 @@ trap cleanup EXIT
 BUILD_FLAG="--build"
 [ "${NO_BUILD:-0}" = "1" ] && BUILD_FLAG=""
 
-echo "── bringing up adversarial sandbox (proxy + waf + dns + mock-upstream) ──"
-# Start the data-plane detached and wait for health, THEN run the attacker as a
-# one-shot. (Not `up --abort-on-container-exit`: that stops the whole stack the
+echo "── bringing up adversarial sandbox (proxy + waf + dns + mock-upstream + backend) ──"
+# Start the data-plane detached and wait for health, THEN run the attacker planes
+# as one-shots. (Not `up --abort-on-container-exit`: that stops the whole stack the
 # moment the attacker exits, which fights KEEP_UP and any post-run inspection.)
-"${DC[@]}" up -d $BUILD_FLAG --wait waf dns proxy mock-upstream
+"${DC[@]}" up -d $BUILD_FLAG --wait waf dns proxy mock-upstream backend
 up_rc=$?
+rc=0
 if [ "$up_rc" -ne 0 ]; then
   echo "error: sandbox failed to become healthy" >&2
   "${DC[@]}" ps
-  rc="$up_rc"
-else
-  "${DC[@]}" run --rm attacker
-  rc=$?
+  exit "$up_rc"
 fi
+
+# Plane 1 — data-plane block-matrix (traffic through proxy + WAF/ICAP).
+echo "── plane 1: block-matrix (proxy + WAF/ICAP) ──"
+"${DC[@]}" run --rm attacker;               p1=$?
+
+# Plane 2 — API attacker (direct to the backend auth boundary).
+echo "── plane 2: API attacker (backend auth boundary) ──"
+"${DC[@]}" run --rm --entrypoint /adversarial/api-attack.sh attacker; p2=$?
+
+[ "$p1" -ne 0 ] && rc=1
+[ "$p2" -ne 0 ] && rc=1
 
 echo
-if [ -f report/report.md ]; then
-  echo "════════════════════════════════════════════════════════════════════════"
-  cat report/report.md
-  echo "════════════════════════════════════════════════════════════════════════"
-else
-  echo "warning: no report produced — inspect logs above" >&2
-fi
+for f in report/report.md report/api-report.md; do
+  if [ -f "$f" ]; then
+    echo "════════════════════════════════════════════════════════════════════════"
+    cat "$f"
+    echo "════════════════════════════════════════════════════════════════════════"
+  fi
+done
 
+echo
+printf '  plane 1 (block-matrix): %s\n' "$([ "$p1" -eq 0 ] && echo PASS || echo FAIL)"
+printf '  plane 2 (API attacker): %s\n' "$([ "$p2" -eq 0 ] && echo PASS || echo FAIL)"
 if [ "$rc" -eq 0 ]; then
   echo "✅ adversarial gate: PASS"
 else
-  echo "❌ adversarial gate: FAIL (exit $rc)"
+  echo "❌ adversarial gate: FAIL"
 fi
 exit "$rc"


### PR DESCRIPTION
## What

Phase 2 of the adversarial harness (#200): a **Plane 2 — API attacker** that hits the backend Go API **directly** and gates on auth/authorization regressions, alongside the Phase 1 block-matrix (#201). The `adversarial` CI job (#202) now exercises both planes.

```
plane 1:  attacker ──http_proxy──▶ proxy (Squid) ──ICAP──▶ waf   (REQMOD / RESPMOD)
                                        └──────────────▶ mock-upstream (controlled)
plane 2:  attacker ─────────────────────────────────────▶ backend (Go API, direct)
```

## Result — green end-to-end

```
plane 1 (block-matrix): cases=33 TP=23 TN=10 FN=0 FP=0        PASS
plane 2 (API attacker): cases=18 pass=18 fail=0 bypasses=0    PASS
```

Plane 2, grounded in the real routes/auth in `backend-go`:

- **Auth-bypass** — protected endpoints (`/api/status`, `/api/settings`, `/api/audit-log`, `/api/database/export`, `/api/database/reset`, `/api/change-password`, `/api/security/rate-limits`) must return **401** unauthenticated; a 2xx is a **bypass** and fails the gate.
- **Forged JWTs** — `alg=none` confusion (claims admin), mutated signature, garbage → **401**.
- **Login SQL-injection** — username tautology / comment payloads → **401** (no bypass).
- **Rate limit** — a concurrent burst (90 reqs) trips the per-IP limiter → **429** (observed 40×).
- **Controls** — legitimate Basic-Auth and JWT access still return **2xx**, and public `/api/health` is reachable.

## Design

- Adds a `backend` service to the sandbox (ephemeral `/config`,`/data` volumes, known test creds `testadmin` / `TestP@ss123!`), on `adv-edge` so the attacker reaches it directly — testing the app's own security boundary, not the WAF.
- `run.sh` brings the backend up and runs both planes as one-shots; the exit code fails if **either** plane fails. Reports: `report/report.md` (plane 1) + `report/api-report.md` (plane 2).
- No new pinned actions; the existing `adversarial` CI job runs both planes and prints both reports to the job log.

## Scope

Phase 2 uses a curated, deterministic corpus (no external nuclei/ZAP images, to keep CI hermetic and flake-free). Templated scans are noted as optional **Phase 2b**. **Phase 3** (bench/latency) and **Phase 4** (resilience) remain tracked in #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)