### PR TITLE
test(adversarial): bench/latency plane via k6 (#200 Phase 3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ clean:
 	@echo "⚠️  Data in ./data/ preserved. Remove manually if needed."
 
 # Adversarial e2e: drive attacker traffic against the real proxy + WAF/ICAP
-# (block-matrix) and the backend auth boundary (API attacker) in an isolated
-# sandbox; gate on false negatives/positives and auth bypasses (#200).
+# (block-matrix), the backend auth boundary (API attacker), and a k6 latency
+# bench, in an isolated sandbox; gate on false negatives/positives, auth
+# bypasses, and p95/error-rate regressions (#200).
 adversarial:
 	bash tests/adversarial/run.sh

--- a/tests/adversarial/README.md
+++ b/tests/adversarial/README.md
@@ -1,12 +1,14 @@
 # Adversarial e2e harness (proxy + WAF data plane, backend API)
 
 Drives attacker-style traffic against the running product in an isolated
-sandbox and gates on security regressions. Two planes:
+sandbox and gates on security regressions. Three planes:
 
 - **Plane 1 — data-plane block-matrix.** Traffic **through the real forward
   proxy + WAF/ICAP**; measures block/allow correctness (FP/FN).
 - **Plane 2 — API attacker.** Hits the **backend's auth boundary directly**
   (auth-bypass, forged/tampered JWTs, login SQLi, rate-limit).
+- **Plane 3 — bench/latency.** k6 load through the proxy + WAF vs a direct
+  baseline; p50/p95, throughput, ICAP overhead, with a p95/error-rate gate.
 
 This is the counterpart to the UI Playwright suite and the API/UI-only
 `docker-compose.test.yml` (which deliberately excludes proxy + WAF).
@@ -95,9 +97,24 @@ mutated signature, garbage), **login SQL-injection**, wrong-password, per-IP
 access still works. A protected endpoint returning 2xx unauthenticated is a
 **bypass** and fails the gate.
 
+### Plane 3 — bench / latency
+
+[`bench/bench.js`](bench/bench.js) — a k6 load test run twice: a **baseline**
+(direct to the mock upstream) and a **proxied** run (through proxy + WAF/ICAP,
+`HTTP_PROXY` set). Each request uses a unique cache-buster URL, so the WAF
+safe-cache and Squid cache both miss and we measure real per-request inspection.
+The report shows p50/p95/p99, throughput, and the **proxy + ICAP overhead**
+(proxied − baseline). k6's thresholds are the gate — it exits non-zero on a
+breach (tunable via env):
+
+| Env | Default | Meaning |
+|---|---|---|
+| `P95_MS` | `800` | proxied p95 latency ceiling (ms) |
+| `MAX_FAIL` | `0.05` | proxied error-rate ceiling |
+| `VUS` / `DURATION` | `10` / `15s` | load shape |
+
 ## Roadmap (later phases, see #200)
 
-- **Phase 3** — bench/latency (k6/vegeta): p50/p95, ICAP overhead, regression gate.
 - **Phase 4** — resilience: kill/restart waf/dns hot; self-heal + fail-closed hold.
 - Optional Phase 2b — templated scans (nuclei / ZAP baseline) layered on the
   same sandbox.

--- a/tests/adversarial/bench/bench.js
+++ b/tests/adversarial/bench/bench.js
@@ -1,0 +1,38 @@
+// Adversarial bench/latency plane (issue #200, Phase 3).
+//
+// Generates benign GET load and measures latency percentiles + throughput.
+// run.sh invokes this twice via docker compose:
+//   - baseline: TARGET=http://mock-upstream/bench          (direct to upstream)
+//   - proxied:  TARGET=http://upstream.test/bench + HTTP_PROXY=proxy:3128
+//               (through the real Squid + WAF/ICAP path)
+// The delta is the proxy + ICAP inspection overhead.
+//
+// Each request uses a unique cache-buster query so the WAF safe-cache and Squid
+// cache both MISS — i.e. we measure real per-request inspection, not cache hits.
+//
+// Thresholds are the regression gate: k6 exits non-zero if p95 latency or the
+// error rate breach them. Tunable via env (P95_MS, MAX_FAIL, VUS, DURATION).
+import http from 'k6/http';
+
+const TARGET = __ENV.TARGET || 'http://upstream.test/bench';
+
+export const options = {
+  scenarios: {
+    load: {
+      executor: 'constant-vus',
+      vus: Number(__ENV.VUS || 10),
+      duration: __ENV.DURATION || '15s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<' + (__ENV.MAX_FAIL || '0.05')],
+    http_req_duration: ['p(95)<' + (__ENV.P95_MS || '800')],
+  },
+  // Keep the end-of-test stdout summary compact; the machine-readable numbers
+  // come from --summary-export (see run.sh).
+  summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+};
+
+export default function () {
+  http.get(`${TARGET}?i=${__VU}x${__ITER}`);
+}

--- a/tests/adversarial/docker-compose.adversarial.yml
+++ b/tests/adversarial/docker-compose.adversarial.yml
@@ -188,6 +188,25 @@ services:
       - adv-edge
     restart: "no"
 
+  # ── Bench / latency (k6) ───────────────────────────────────────────────────
+  # One-shot load generator (Phase 3). run.sh drives it twice via `compose run`:
+  # a baseline (direct to mock-upstream) and a proxied run (through proxy + WAF,
+  # HTTP_PROXY set), then reports the p50/p95/throughput and the ICAP overhead.
+  # k6's thresholds are the gate: it exits non-zero on a p95 / error-rate breach.
+  k6:
+    image: grafana/k6:0.55.0
+    depends_on:
+      proxy:
+        condition: service_healthy
+      mock-upstream:
+        condition: service_healthy
+    volumes:
+      - ./bench:/bench:ro
+      - ./report:/report
+    networks:
+      - adv-edge
+    restart: "no"
+
   # ── Attacker ───────────────────────────────────────────────────────────────
   # Runs the corpus through the proxy, writes the block-matrix + FP/FN report to
   # ./report, and exits with the CI gate code (non-zero on hard FN/FP).

--- a/tests/adversarial/run.sh
+++ b/tests/adversarial/run.sh
@@ -114,9 +114,12 @@ echo "── plane 2: API attacker (backend auth boundary) ──"
 # Plane 3 — bench/latency (k6). Baseline (direct) is informational; the proxied
 # run through proxy + WAF carries the thresholds and is the gate.
 echo "── plane 3: bench/latency (k6 through proxy + WAF) ──"
-"${DC[@]}" run --rm -e TARGET=http://mock-upstream/bench \
+# --user 0: k6's image drops root, but the ./report bind mount is owned by the
+# host/CI user, so a non-root k6 can't write the --summary-export file there
+# (works on Docker Desktop only because it remaps ownership). Run as uid 0.
+"${DC[@]}" run --rm --user 0 -e TARGET=http://mock-upstream/bench \
   k6 run --quiet --summary-export=/report/bench-baseline.json /bench/bench.js >/dev/null 2>&1 || true
-"${DC[@]}" run --rm -e TARGET=http://upstream.test/bench -e HTTP_PROXY=http://proxy:3128 \
+"${DC[@]}" run --rm --user 0 -e TARGET=http://upstream.test/bench -e HTTP_PROXY=http://proxy:3128 \
   k6 run --quiet --summary-export=/report/bench-proxied.json /bench/bench.js; p3=$?
 bench_report
 

--- a/tests/adversarial/run.sh
+++ b/tests/adversarial/run.sh
@@ -35,7 +35,46 @@ fi
 DC=("$DOCKER" compose -f docker-compose.adversarial.yml)
 
 mkdir -p report
-rm -f report/report.md report/report.json report/results.json
+rm -f report/report.md report/report.json report/results.json \
+      report/api-report.md report/api-report.json report/api-results.json \
+      report/bench-report.md report/bench-baseline.json report/bench-proxied.json
+
+# Build the plane-3 bench report from k6's summary exports (baseline vs proxied),
+# reporting p50/p95/throughput and the proxy + ICAP overhead.
+bench_report() {
+  local bl=report/bench-baseline.json pr=report/bench-proxied.json
+  command -v jq >/dev/null 2>&1 || { echo "warning: jq not found; skipping bench report"; return; }
+  [ -f "$pr" ] || { echo "warning: no proxied bench summary produced"; return; }
+  # k6 --summary-export is FLAT: .metrics.<name>.<stat> (no ".values").
+  local dur='.metrics.http_req_duration'
+  local p_p50 p_p95 p_p99 p_rps p_err b_p50 b_p95 b_rps
+  p_p50=$(jq -r "${dur}.med // 0"       "$pr"); p_p95=$(jq -r "${dur}[\"p(95)\"] // 0" "$pr")
+  p_p99=$(jq -r "${dur}[\"p(99)\"] // 0" "$pr"); p_rps=$(jq -r '.metrics.http_reqs.rate // 0' "$pr")
+  p_err=$(jq -r '.metrics.http_req_failed.value // 0' "$pr")
+  if [ -f "$bl" ]; then
+    b_p50=$(jq -r "${dur}.med // 0" "$bl"); b_p95=$(jq -r "${dur}[\"p(95)\"] // 0" "$bl")
+    b_rps=$(jq -r '.metrics.http_reqs.rate // 0' "$bl")
+  else b_p50=0; b_p95=0; b_rps=0; fi
+  local ov50 ov95
+  ov50=$(awk -v a="$p_p50" -v b="$b_p50" 'BEGIN{printf "%.2f", a-b}')
+  ov95=$(awk -v a="$p_p95" -v b="$b_p95" 'BEGIN{printf "%.2f", a-b}')
+  {
+    echo "# Bench / latency report"
+    echo
+    echo "> Load through the real proxy + WAF/ICAP vs a direct baseline (#200 Phase 3)."
+    echo "> Unique per-request URL (cache-buster) → measures real inspection, not cache hits."
+    echo
+    echo "| Metric (ms unless noted) | Baseline (direct) | Proxied (proxy+WAF) | Overhead |"
+    echo "|---|--:|--:|--:|"
+    printf '| p50 latency | %.2f | %.2f | %s |\n' "$b_p50" "$p_p50" "$ov50"
+    printf '| p95 latency | %.2f | %.2f | %s |\n' "$b_p95" "$p_p95" "$ov95"
+    printf '| p99 latency | – | %.2f | – |\n' "$p_p99"
+    printf '| throughput (req/s) | %.1f | %.1f | – |\n' "$b_rps" "$p_rps"
+    printf '| error rate | – | %.4f | – |\n' "$p_err"
+    echo
+    echo "_Gate (proxied run): p95 < ${P95_MS:-800} ms and error rate < ${MAX_FAIL:-0.05} (k6 thresholds)._"
+  } >report/bench-report.md
+}
 
 cleanup() {
   if [ "${KEEP_UP:-0}" = "1" ]; then
@@ -72,11 +111,21 @@ echo "── plane 1: block-matrix (proxy + WAF/ICAP) ──"
 echo "── plane 2: API attacker (backend auth boundary) ──"
 "${DC[@]}" run --rm --entrypoint /adversarial/api-attack.sh attacker; p2=$?
 
+# Plane 3 — bench/latency (k6). Baseline (direct) is informational; the proxied
+# run through proxy + WAF carries the thresholds and is the gate.
+echo "── plane 3: bench/latency (k6 through proxy + WAF) ──"
+"${DC[@]}" run --rm -e TARGET=http://mock-upstream/bench \
+  k6 run --quiet --summary-export=/report/bench-baseline.json /bench/bench.js >/dev/null 2>&1 || true
+"${DC[@]}" run --rm -e TARGET=http://upstream.test/bench -e HTTP_PROXY=http://proxy:3128 \
+  k6 run --quiet --summary-export=/report/bench-proxied.json /bench/bench.js; p3=$?
+bench_report
+
 [ "$p1" -ne 0 ] && rc=1
 [ "$p2" -ne 0 ] && rc=1
+[ "$p3" -ne 0 ] && rc=1
 
 echo
-for f in report/report.md report/api-report.md; do
+for f in report/report.md report/api-report.md report/bench-report.md; do
   if [ -f "$f" ]; then
     echo "════════════════════════════════════════════════════════════════════════"
     cat "$f"
@@ -87,6 +136,7 @@ done
 echo
 printf '  plane 1 (block-matrix): %s\n' "$([ "$p1" -eq 0 ] && echo PASS || echo FAIL)"
 printf '  plane 2 (API attacker): %s\n' "$([ "$p2" -eq 0 ] && echo PASS || echo FAIL)"
+printf '  plane 3 (bench/latency): %s\n' "$([ "${p3:-1}" -eq 0 ] && echo PASS || echo FAIL)"
 if [ "$rc" -eq 0 ]; then
   echo "✅ adversarial gate: PASS"
 else


### PR DESCRIPTION
## What

Phase 3 of the adversarial harness (#200): a **Plane 3 — bench/latency** that measures the proxy + WAF/ICAP data-plane's latency percentiles and throughput, and gates on a p95/error-rate regression. The `adversarial` CI job now runs all three planes.

## How

- New `k6` service (`grafana/k6:0.55.0`) + [`bench/bench.js`](tests/adversarial/bench/bench.js).
- `run.sh` runs k6 twice:
  - **baseline** — direct to the mock upstream,
  - **proxied** — through proxy + WAF/ICAP (`HTTP_PROXY` set).
- Each request uses a **unique cache-buster URL**, so the WAF safe-cache and Squid cache both miss — it measures real per-request inspection, not cache hits.
- The report shows p50/p95/p99, throughput, and the **proxy + ICAP overhead** (proxied − baseline).
- **Gate** = k6 thresholds on the proxied run: `p95 < ${P95_MS:-800}` ms and error rate `< ${MAX_FAIL:-0.05}` (tunable via env); k6 exits non-zero on a breach.

## Result (local, 10 VUs / 15 s)

| Metric | Baseline (direct) | Proxied (proxy+WAF) | Overhead |
|---|--:|--:|--:|
| p50 | 0.16 ms | 2.26 ms | +2.10 ms |
| p95 | 1.35 ms | 5.35 ms | +4.00 ms |
| p99 | – | 9.57 ms | – |
| throughput | 16058 req/s | 3665 req/s | – |
| error rate | – | 0.0000 | – |

All three gates green: `plane 1 PASS · plane 2 PASS · plane 3 PASS`.

## Scope

**Phase 4** (resilience: kill/restart waf/dns hot, self-heal + fail-closed) remains tracked in #200. Thresholds are intentionally generous for a first gate and tunable via env — tighten once CI has a baseline track record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)