### PR TITLE
test(adversarial): resilience plane — fail-closed + self-heal (#200 Phase 4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ clean:
 	@echo "⚠️  Data in ./data/ preserved. Remove manually if needed."
 
 # Adversarial e2e: drive attacker traffic against the real proxy + WAF/ICAP
-# (block-matrix), the backend auth boundary (API attacker), and a k6 latency
-# bench, in an isolated sandbox; gate on false negatives/positives, auth
-# bypasses, and p95/error-rate regressions (#200).
+# (block-matrix), the backend auth boundary (API attacker), a k6 latency bench,
+# and a resilience sweep (fail-closed + self-heal), in an isolated sandbox; gate
+# on FN/FP, auth bypasses, p95/error-rate regressions, and fail-open holes (#200).
 adversarial:
 	bash tests/adversarial/run.sh

--- a/tests/adversarial/README.md
+++ b/tests/adversarial/README.md
@@ -1,7 +1,7 @@
 # Adversarial e2e harness (proxy + WAF data plane, backend API)
 
 Drives attacker-style traffic against the running product in an isolated
-sandbox and gates on security regressions. Three planes:
+sandbox and gates on security regressions. Four planes:
 
 - **Plane 1 — data-plane block-matrix.** Traffic **through the real forward
   proxy + WAF/ICAP**; measures block/allow correctness (FP/FN).
@@ -9,6 +9,8 @@ sandbox and gates on security regressions. Three planes:
   (auth-bypass, forged/tampered JWTs, login SQLi, rate-limit).
 - **Plane 3 — bench/latency.** k6 load through the proxy + WAF vs a direct
   baseline; p50/p95, throughput, ICAP overhead, with a p95/error-rate gate.
+- **Plane 4 — resilience.** Kills/restarts waf & dns and asserts the WAF
+  **fails closed** (no fail-open hole) and the stack **self-heals**.
 
 This is the counterpart to the UI Playwright suite and the API/UI-only
 `docker-compose.test.yml` (which deliberately excludes proxy + WAF).
@@ -113,8 +115,19 @@ breach (tunable via env):
 | `MAX_FAIL` | `0.05` | proxied error-rate ceiling |
 | `VUS` / `DURATION` | `10` / `15s` | load shape |
 
+### Plane 4 — resilience
+
+No corpus — a scripted failure sequence in `run.sh`, probing through the proxy
+from a throwaway container while it stops/starts services:
+
+| Check | Asserts |
+|---|---|
+| `baseline` | benign → 200 while healthy |
+| `waf-fail-closed` | WAF stopped → benign is **not** 200 (REQMOD `bypass=0` denies; a 200 would be a fail-**open** hole) |
+| `waf-self-heal` | WAF restarted → benign 200 **and** malicious 403 (ruleset/ISTag intact) |
+| `dns-self-heal` | dns recycled → traffic flows again (200) |
+
 ## Roadmap (later phases, see #200)
 
-- **Phase 4** — resilience: kill/restart waf/dns hot; self-heal + fail-closed hold.
 - Optional Phase 2b — templated scans (nuclei / ZAP baseline) layered on the
-  same sandbox.
+  same sandbox; tighten the bench thresholds once CI has a baseline.

--- a/tests/adversarial/run.sh
+++ b/tests/adversarial/run.sh
@@ -37,7 +37,8 @@ DC=("$DOCKER" compose -f docker-compose.adversarial.yml)
 mkdir -p report
 rm -f report/report.md report/report.json report/results.json \
       report/api-report.md report/api-report.json report/api-results.json \
-      report/bench-report.md report/bench-baseline.json report/bench-proxied.json
+      report/bench-report.md report/bench-baseline.json report/bench-proxied.json \
+      report/resilience-report.md
 
 # Build the plane-3 bench report from k6's summary exports (baseline vs proxied),
 # reporting p50/p95/throughput and the proxy + ICAP overhead.
@@ -74,6 +75,89 @@ bench_report() {
     echo
     echo "_Gate (proxied run): p95 < ${P95_MS:-800} ms and error rate < ${MAX_FAIL:-0.05} (k6 thresholds)._"
   } >report/bench-report.md
+}
+
+# Plane 4 — resilience. Kills/restarts waf and dns and asserts the two properties
+# that matter under failure: (1) losing the WAF FAILS CLOSED (a benign request
+# is denied, not served uninspected — no fail-open hole), and (2) the stack
+# self-heals (blocking resumes after the WAF returns; traffic flows after dns is
+# recycled). Sets the global P4_RC. Runs LAST (it disrupts the data plane).
+P4_RC=0
+resilience() {
+  local RESREC=() name detail v s sb sm
+  add() { RESREC+=("$1|$2|$3"); }
+
+  # Probe through the proxy from a throwaway attacker container on adv-edge.
+  # --no-deps: don't wait on service health (the proxy goes unhealthy while the
+  # WAF is down, but squid still answers — with an ICAP error, which is the point).
+  probe() {
+    # curl -w always prints a code (000 on no response); </dev/null so the
+    # container never consumes the caller's stdin. Compose progress is on stderr.
+    "${DC[@]}" run --rm --no-deps -T --entrypoint curl attacker \
+      -s -o /dev/null -w '%{http_code}' --max-time 12 --path-as-is \
+      -x http://proxy:3128 "http://upstream.test$1" </dev/null 2>/dev/null
+  }
+  wait_healthy() {
+    local svc=$1 tries=${2:-30} h
+    for _ in $(seq 1 "$tries"); do
+      h=$("$DOCKER" inspect -f '{{.State.Health.Status}}' "spm-adversarial-${svc}-1" 2>/dev/null || echo none)
+      [ "$h" = "healthy" ] && return 0
+      sleep 2
+    done
+    return 1
+  }
+
+  # R1 — baseline: benign is served while everything is healthy.
+  s=$(probe /index.html)
+  if [ "$s" = "200" ]; then v=PASS; else v=FAIL; P4_RC=1; fi
+  add "baseline" "benign→$s (want 200)" "$v"
+
+  # R2 — WAF fail-closed: with the WAF down, REQMOD (bypass=0) must NOT let a
+  # request through uninspected. A 200 here would be a fail-OPEN security hole.
+  "${DC[@]}" stop waf >/dev/null 2>&1
+  sleep 3
+  s=$(probe /index.html)
+  if [ "$s" != "200" ]; then v=PASS; else v=FAIL; P4_RC=1; fi
+  add "waf-fail-closed" "waf down: benign→$s (want NOT 200)" "$v"
+
+  # R3 — WAF self-heal: after the WAF returns, benign flows again AND malicious
+  # is still blocked (ruleset/ISTag intact). Retry: squid reconnects ICAP lazily.
+  "${DC[@]}" start waf >/dev/null 2>&1
+  if wait_healthy waf; then
+    sb=000; for _ in 1 2 3 4 5 6; do sb=$(probe /index.html); [ "$sb" = "200" ] && break; sleep 2; done
+    sm=$(probe "/p?id=1%20UNION%20SELECT%20a%20FROM%20b")
+    if [ "$sb" = "200" ] && [ "$sm" = "403" ]; then v=PASS; else v=FAIL; P4_RC=1; fi
+    add "waf-self-heal" "recovered: benign→$sb (want 200), malicious→$sm (want 403)" "$v"
+  else
+    add "waf-self-heal" "waf did not become healthy after restart" "FAIL"; P4_RC=1
+  fi
+
+  # R4 — DNS self-heal: recycle dns and confirm resolution/traffic recovers.
+  "${DC[@]}" restart dns >/dev/null 2>&1
+  if wait_healthy dns; then
+    sleep 2
+    sb=000; for _ in 1 2 3 4 5; do sb=$(probe /index.html); [ "$sb" = "200" ] && break; sleep 2; done
+    if [ "$sb" = "200" ]; then v=PASS; else v=FAIL; P4_RC=1; fi
+    add "dns-self-heal" "dns recycled: benign→$sb (want 200)" "$v"
+  else
+    add "dns-self-heal" "dns did not become healthy after restart" "FAIL"; P4_RC=1
+  fi
+
+  {
+    echo "# Resilience report"
+    echo
+    echo "> Fail-closed on WAF loss + self-heal under failure (#200 Phase 4)."
+    echo
+    echo "| Check | Detail | Verdict |"
+    echo "|---|---|---|"
+    for r in "${RESREC[@]}"; do
+      name=${r%%|*}; detail=${r#*|}; v=${detail##*|}; detail=${detail%|*}
+      printf '| %s | %s | %s |\n' "$name" "$detail" "$v"
+    done
+    echo
+    if [ "$P4_RC" -eq 0 ]; then echo "_Gate: **PASS** — fail-closed held and the stack self-healed._"
+    else echo "_Gate: **FAIL** — see the checks above._"; fi
+  } >report/resilience-report.md
 }
 
 cleanup() {
@@ -123,12 +207,18 @@ echo "── plane 3: bench/latency (k6 through proxy + WAF) ──"
   k6 run --quiet --summary-export=/report/bench-proxied.json /bench/bench.js; p3=$?
 bench_report
 
+# Plane 4 — resilience (fail-closed + self-heal). Runs last: it disrupts the
+# data plane by stopping/starting waf and dns.
+echo "── plane 4: resilience (fail-closed + self-heal) ──"
+resilience; p4=$P4_RC
+
 [ "$p1" -ne 0 ] && rc=1
 [ "$p2" -ne 0 ] && rc=1
 [ "$p3" -ne 0 ] && rc=1
+[ "$p4" -ne 0 ] && rc=1
 
 echo
-for f in report/report.md report/api-report.md report/bench-report.md; do
+for f in report/report.md report/api-report.md report/bench-report.md report/resilience-report.md; do
   if [ -f "$f" ]; then
     echo "════════════════════════════════════════════════════════════════════════"
     cat "$f"
@@ -140,6 +230,7 @@ echo
 printf '  plane 1 (block-matrix): %s\n' "$([ "$p1" -eq 0 ] && echo PASS || echo FAIL)"
 printf '  plane 2 (API attacker): %s\n' "$([ "$p2" -eq 0 ] && echo PASS || echo FAIL)"
 printf '  plane 3 (bench/latency): %s\n' "$([ "${p3:-1}" -eq 0 ] && echo PASS || echo FAIL)"
+printf '  plane 4 (resilience): %s\n' "$([ "${p4:-1}" -eq 0 ] && echo PASS || echo FAIL)"
 if [ "$rc" -eq 0 ]; then
   echo "✅ adversarial gate: PASS"
 else


### PR DESCRIPTION
## What

Phase 4 (the last) of the adversarial harness (#200): a **Plane 4 — resilience** sweep that kills/restarts `waf` and `dns` and asserts the properties that matter under failure. The `adversarial` CI job now runs all four planes.

## Checks

| Check | Asserts |
|---|---|
| `baseline` | benign → 200 while healthy |
| **`waf-fail-closed`** | WAF stopped → benign is **not** 200 (REQMOD `bypass=0` denies; a 200 would be a fail-**open** security hole) |
| `waf-self-heal` | WAF restarted → benign 200 **and** malicious 403 (ruleset/ISTag intact) |
| `dns-self-heal` | dns recycled → traffic flows again (200) |

Probes run through the proxy from a throwaway container on `adv-edge`; kill/restart is host-side via `docker compose`. Squid reconnects ICAP lazily after the WAF returns, so the recovery probe retries. Emits `report/resilience-report.md`; a fail-open or a failed self-heal fails the gate.

## Result — all four planes green

```
plane 1 (block-matrix):  FN=0 FP=0                         PASS
plane 2 (API attacker):  18/18, 0 bypass                   PASS
plane 3 (bench/latency): p95 ~12ms < 800ms, 0% err         PASS
plane 4 (resilience):    fail-closed held + self-healed     PASS
```

Resilience detail (local):

```
baseline         benign→200                       PASS
waf-fail-closed  waf down: benign→000 (NOT 200)    PASS
waf-self-heal    benign→200, malicious→403         PASS
dns-self-heal    dns recycled: benign→200          PASS
```

This closes the four-phase #200 initiative. Optional follow-ups noted there: nuclei/ZAP templated scans (Phase 2b) and tightening the bench thresholds once CI has a baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)