### PR TITLE
feat(correlation): carry the WAF event-id into the Squid log → proxy_logs (#107)

### DIFF
--- a/backend-go/internal/database/db.go
+++ b/backend-go/internal/database/db.go
@@ -113,7 +113,8 @@ func Init(db *sql.DB, adminUsername, adminPasswordHash string) error {
 			bytes INTEGER,
 			elapsed_ms INTEGER,
 			unix_timestamp INTEGER,
-			blocked INTEGER NOT NULL DEFAULT 0
+			blocked INTEGER NOT NULL DEFAULT 0,
+			event_id TEXT
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_proxy_logs_timestamp ON proxy_logs(timestamp)`,
 		`CREATE INDEX IF NOT EXISTS idx_proxy_logs_source_ip ON proxy_logs(source_ip)`,
@@ -150,6 +151,7 @@ func Init(db *sql.DB, adminUsername, adminPasswordHash string) error {
 		"ALTER TABLE proxy_logs ADD COLUMN method TEXT",
 		"ALTER TABLE proxy_logs ADD COLUMN elapsed_ms INTEGER",
 		"ALTER TABLE proxy_logs ADD COLUMN blocked INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE proxy_logs ADD COLUMN event_id TEXT", // WAF correlation id (#107)
 		"ALTER TABLE domain_whitelist ADD COLUMN type TEXT DEFAULT 'fqdn'",
 	}
 	for _, m := range migrations {
@@ -163,6 +165,9 @@ func Init(db *sql.DB, adminUsername, adminPasswordHash string) error {
 	// upgrade. Only blocked rows are indexed, so it stays tiny.
 	postMigrationIndexes := []string{
 		`CREATE INDEX IF NOT EXISTS idx_proxy_logs_blocked ON proxy_logs(blocked) WHERE blocked = 1`,
+		// Correlation-id lookup (join a WAF event → its proxy_logs row). Partial:
+		// only blocked rows carry an event_id, so the index stays tiny (#107).
+		`CREATE INDEX IF NOT EXISTS idx_proxy_logs_event_id ON proxy_logs(event_id) WHERE event_id IS NOT NULL`,
 	}
 	for _, stmt := range postMigrationIndexes {
 		if _, err := db.Exec(stmt); err != nil {

--- a/backend-go/internal/workers/log_tailer.go
+++ b/backend-go/internal/workers/log_tailer.go
@@ -171,6 +171,16 @@ func parseSquidLine(line string) map[string]any {
 		blocked = 1
 	}
 
+	// Field 10 (11th): WAF correlation id, present only when the custom `spm`
+	// logformat is active AND the WAF stamped X-WAF-Event-Id on a blocked reply.
+	// Squid logs '-' when the header is absent (allowed requests, or the stock
+	// logformat), which we normalize to empty. Guarded by length so a stock
+	// 10-field line still parses with no regression (#107).
+	eventID := ""
+	if len(fields) >= 11 && fields[10] != "-" {
+		eventID = fields[10]
+	}
+
 	return map[string]any{
 		"timestamp":      timestamp,
 		"unix_timestamp": unixSec,
@@ -182,6 +192,7 @@ func parseSquidLine(line string) map[string]any {
 		"bytes":          bytesInt,
 		"elapsed_ms":     elapsed,
 		"blocked":        blocked,
+		"event_id":       eventID,
 	}
 }
 
@@ -210,8 +221,8 @@ func insertLogBatch(db *sql.DB, entries []map[string]any) error {
 		return err
 	}
 	stmt, err := tx.Prepare(
-		`INSERT INTO proxy_logs(timestamp, unix_timestamp, source_ip, method, destination, status, bytes, elapsed_ms, blocked)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		`INSERT INTO proxy_logs(timestamp, unix_timestamp, source_ip, method, destination, status, bytes, elapsed_ms, blocked, event_id)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -228,6 +239,7 @@ func insertLogBatch(db *sql.DB, entries []map[string]any) error {
 		if _, err := stmt.Exec(
 			e["timestamp"], e["unix_timestamp"], e["source_ip"], e["method"],
 			e["destination"], e["status"], e["bytes"], e["elapsed_ms"], blocked,
+			e["event_id"],
 		); err != nil {
 			_ = tx.Rollback()
 			return err

--- a/backend-go/internal/workers/workers_test.go
+++ b/backend-go/internal/workers/workers_test.go
@@ -159,14 +159,22 @@ func TestInsertLogBatch(t *testing.T) {
 			"source_ip":      "192.168.1.1",
 			"method":         "GET",
 			"destination":    "http://example.com",
-			"status":         "TCP_MISS/200",
+			"status":         "TCP_DENIED/403",
 			"bytes":          1024,
 			"elapsed_ms":     12,
+			"event_id":       "abc123-1f",
 		},
-		{"source_ip": "1.2.3.4"}, // partial map — must not break the batch
+		{"source_ip": "1.2.3.4"}, // partial map (no event_id) — must not break the batch
 	}
 	if err := insertLogBatch(db, batch); err != nil {
 		t.Fatalf("insertLogBatch: %v", err)
+	}
+
+	// The correlation id round-trips into its column.
+	var gotID string
+	_ = db.QueryRow("SELECT event_id FROM proxy_logs WHERE event_id = 'abc123-1f'").Scan(&gotID)
+	if gotID != "abc123-1f" {
+		t.Errorf("event_id not persisted; got %q", gotID)
 	}
 
 	var count int
@@ -219,6 +227,31 @@ func TestParseSquidLine(t *testing.T) {
 func TestParseSquidLine_Edge(t *testing.T) {
 	if parseSquidLine("invalid") != nil {
 		t.Error("Expected nil for invalid line")
+	}
+}
+
+func TestParseSquidLine_EventID(t *testing.T) {
+	// 11-field `spm` line: the trailing field is the WAF correlation id.
+	withID := "1234567890.123 100 127.0.0.1 TCP_DENIED/403 0 GET http://evil.com - HIER_NONE/- text/html abc123-1f"
+	got := parseSquidLine(withID)
+	if got == nil {
+		t.Fatal("expected a parsed map for an 11-field line")
+	}
+	if got["event_id"] != "abc123-1f" {
+		t.Errorf("event_id = %v; want abc123-1f", got["event_id"])
+	}
+
+	// A '-' in the 11th field (allowed request / header absent) → empty.
+	dash := "1234567890.123 100 127.0.0.1 TCP_MISS/200 1024 GET http://example.com - DIRECT/1.2.3.4 text/html -"
+	if got = parseSquidLine(dash); got["event_id"] != "" {
+		t.Errorf("event_id for '-' = %v; want empty", got["event_id"])
+	}
+
+	// Stock 10-field line (no event id column) still parses, event_id empty — no
+	// ingestion regression if the custom logformat isn't applied.
+	stock := "1234567890.123 100 127.0.0.1 TCP_MISS/200 1024 GET http://example.com - DIRECT/1.2.3.4 text/html"
+	if got = parseSquidLine(stock); got == nil || got["event_id"] != "" {
+		t.Errorf("stock line: got %v; want parsed with empty event_id", got)
 	}
 }
 

--- a/proxy/generate_squid_conf.sh
+++ b/proxy/generate_squid_conf.sh
@@ -281,7 +281,14 @@ adaptation_access service_resp allow all
 # blacklist watchdog sidecar).
 debug_options ALL,1
 logfile_rotate 5
-access_log daemon:/var/log/squid/access.log squid
+# Custom 'spm' logformat = the 10 stock `squid` fields IN EXACT ORDER (the
+# backend's parseSquidLine is positional and requires >=10 of them, so these must
+# not change) + an 11th field carrying the WAF correlation id. The WAF stamps
+# X-WAF-Event-Id on the 403 it returns via ICAP REQMOD; %{...}<h reads it from the
+# reply headers. Allowed requests carry no such header → Squid logs '-' there,
+# which parseSquidLine treats as empty (issue #107).
+logformat spm %ts.%03tu %6tr %>a %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt %{X-WAF-Event-Id}<h
+access_log daemon:/var/log/squid/access.log spm
 cache_log /var/log/squid/cache.log
 cache_store_log none
 

--- a/waf-go/main.go
+++ b/waf-go/main.go
@@ -317,7 +317,7 @@ func recoverICAP(w icap.ResponseWriter, method string) {
 	if r := recover(); r != nil {
 		log.Printf("PANIC in %s handler: %v\n%s", method, r, debug.Stack())
 		if method == "REQMOD" && !wafFailOpen {
-			sendBlockResponse(w, "WAF_INTERNAL_ERROR", blockThreshold)
+			sendBlockResponse(w, "WAF_INTERNAL_ERROR", blockThreshold, "")
 			return
 		}
 		w.WriteHeader(204, nil, false)
@@ -624,7 +624,7 @@ func handleReqmod(w icap.ResponseWriter, req *icap.Request) {
 			notifyDropped.Add(1)
 		}
 
-		sendBlockResponse(w, primaryCategory, score)
+		sendBlockResponse(w, primaryCategory, score, eventID)
 		return
 	}
 
@@ -656,7 +656,7 @@ func handleRespmod(w icap.ResponseWriter, req *icap.Request) {
 	for _, dt := range dangerousTypes {
 		if strings.Contains(contentTypeLower, dt) {
 			log.Printf("RESPMOD blocked dangerous content-type: %s\n", contentType)
-			sendBlockResponse(w, "DANGEROUS_CONTENT_TYPE", 10)
+			sendBlockResponse(w, "DANGEROUS_CONTENT_TYPE", 10, "")
 			return
 		}
 	}
@@ -706,7 +706,7 @@ func handleRespmod(w icap.ResponseWriter, req *icap.Request) {
 			if totalScore >= blockThreshold {
 				log.Printf("RESPMOD BLOCKED score=%d rules=[%s] content-type=%s\n",
 					totalScore, strings.Join(matchedRules, ","), contentType)
-				sendBlockResponse(w, matchedCat, totalScore)
+				sendBlockResponse(w, matchedCat, totalScore, "")
 				return
 			}
 			_ = piiScore
@@ -716,7 +716,12 @@ func handleRespmod(w icap.ResponseWriter, req *icap.Request) {
 	w.WriteHeader(204, nil, false)
 }
 
-func sendBlockResponse(w icap.ResponseWriter, category string, score int) {
+// sendBlockResponse encapsulates a 403 in the ICAP reply. When eventID is
+// non-empty it is stamped on the response as X-WAF-Event-Id so the same
+// correlation ID that lands in the WAF traffic log + notification can be picked
+// up by Squid's access log (custom `spm` logformat) and joined to the
+// proxy_logs row end-to-end (issue #107).
+func sendBlockResponse(w icap.ResponseWriter, category string, score int, eventID string) {
 	body := fmt.Sprintf(
 		`<html><body><h1>403 Forbidden</h1><p>Request blocked by WAF.</p><p>Category: <b>%s</b> | Score: %d</p></body></html>`,
 		html.EscapeString(category), score)
@@ -732,6 +737,9 @@ func sendBlockResponse(w icap.ResponseWriter, category string, score int) {
 		ContentLength: int64(len(body)),
 	}
 	resp.Header.Set("Content-Type", "text/html")
+	if eventID != "" {
+		resp.Header.Set("X-WAF-Event-Id", eventID)
+	}
 	w.WriteHeader(200, resp, true)
 }
 


### PR DESCRIPTION
## What

Follow-up to the WAF-minted correlation event-id (5a): extends the same id **end-to-end** to the Squid access log → `proxy_logs` row (5b), so a blocked request in the Logs page / analytics joins back to its WAF traffic-log record + notification.

## Changes

- **waf-go** — `sendBlockResponse` stamps `X-WAF-Event-Id: <eventID>` on the 403 returned via ICAP REQMOD (empty id → no header; RESPMOD / internal-error blocks pass `""`).
- **proxy** — custom `spm` logformat = the **10 stock `squid` fields in exact order** + an 11th field `%{X-WAF-Event-Id}<h`; `access_log` switched `squid` → `spm`.
- **backend** — `event_id TEXT` column (CREATE + idempotent ALTER + partial index, ordered after the column migrations per the #104 lesson); `parseSquidLine` reads field 11 (guarded by `len>=11`; `-` → empty), threaded into the insert and the websocket broadcast.

## Live verification (the risk the issue called out)

The issue flagged that `%{X-WAF-Event-Id}<h` and positional-parse fragility needed **live** validation, not just CI. Verified in the adversarial sandbox against the **real Squid build**:

```
blocked SQLi request:
  WAF JSONL   : {"event_id":"dkendz120kkm-6", ... "waf_rules":["SQLi-001"],"action":"block"}
  Squid log f11: dkendz120kkm-6            ← same id
allowed request:
  Squid log    : ... text/html -          ← field 11 '-' → empty event_id, 11 fields intact
```

- ✅ A blocked request shows the **same `event_id`** in the WAF JSONL and its `proxy_logs` row.
- ✅ `parseSquidLine` still parses every normal line (allowed → `-` → empty; a stock 10-field line still parses — no ingestion regression). Also covered by new unit tests + the full-stack `E2E (compose up + smoke)` job, which asserts `total_requests` keeps incrementing (i.e. ingestion isn't broken).

## Coverage gaps (documented, acceptable)

Allowed requests (204, no modified reply) carry no header → `event_id` is empty for non-blocked rows (those are the rows you don't need to trace). SSL-bumped CONNECT tunnels may not get a per-inner-request header.

Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)