### PR TITLE
test(adversarial): config-matrix plane — settings flip the data plane (#200 Phase 5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,10 @@ clean:
 	docker compose down -v --remove-orphans
 	@echo "⚠️  Data in ./data/ preserved. Remove manually if needed."
 
-# Adversarial e2e: drive attacker traffic against the real proxy + WAF/ICAP
-# (block-matrix), the backend auth boundary (API attacker), a k6 latency bench,
-# and a resilience sweep (fail-closed + self-heal), in an isolated sandbox; gate
-# on FN/FP, auth bypasses, p95/error-rate regressions, and fail-open holes (#200).
+# Adversarial e2e: 5-plane suite against the real stack in an isolated sandbox —
+# block-matrix (proxy+WAF/ICAP), API attacker (backend auth), k6 latency bench,
+# resilience (fail-closed + self-heal), and config-matrix (settings flip the data
+# plane); gates on FN/FP, auth bypasses, p95/error-rate, fail-open, and settings
+# that don't take effect (#200).
 adversarial:
 	bash tests/adversarial/run.sh

--- a/tests/adversarial/README.md
+++ b/tests/adversarial/README.md
@@ -1,7 +1,7 @@
 # Adversarial e2e harness (proxy + WAF data plane, backend API)
 
 Drives attacker-style traffic against the running product in an isolated
-sandbox and gates on security regressions. Four planes:
+sandbox and gates on security regressions. Five planes:
 
 - **Plane 1 — data-plane block-matrix.** Traffic **through the real forward
   proxy + WAF/ICAP**; measures block/allow correctness (FP/FN).
@@ -11,6 +11,10 @@ sandbox and gates on security regressions. Four planes:
   baseline; p50/p95, throughput, ICAP overhead, with a p95/error-rate gate.
 - **Plane 4 — resilience.** Kills/restarts waf & dns and asserts the WAF
   **fails closed** (no fail-open hole) and the stack **self-heals**.
+- **Plane 5 — config-matrix.** Flips WAF settings through the real backend→WAF
+  push path and asserts the **data plane changes** accordingly (a disabled
+  rule-category's attack now passes; another category still blocks; re-enable
+  blocks again) — proving settings actually take effect, selectively.
 
 This is the counterpart to the UI Playwright suite and the API/UI-only
 `docker-compose.test.yml` (which deliberately excludes proxy + WAF).
@@ -126,6 +130,26 @@ from a throwaway container while it stops/starts services:
 | `waf-fail-closed` | WAF stopped → benign is **not** 200 (REQMOD `bypass=0` denies; a 200 would be a fail-**open** hole) |
 | `waf-self-heal` | WAF restarted → benign 200 **and** malicious 403 (ruleset/ISTag intact) |
 | `dns-self-heal` | dns recycled → traffic flows again (200) |
+
+### Plane 5 — config-matrix
+
+No corpus — a scripted sequence in `attacker/config-matrix.sh` that flips WAF
+rule-category toggles via `POST /api/waf/categories/toggle` (the real
+backend→WAF push path) and probes through the proxy. Each probe uses a unique
+cache-buster so neither Squid nor the WAF safe-cache serves a stale verdict (a
+category toggle also bumps the WAF ISTag).
+
+| Check | Asserts |
+|---|---|
+| `baseline-*-blocked` | SQLi & XSS both blocked at default config |
+| `*-disabled-passes` | disabling a category lets **that** attack through |
+| `*-still-blocks-while-*-off` | a **different** category still blocks (selective) |
+| `*-reenabled-blocks` | re-enabling restores blocking |
+
+Covers WAF category toggles today. A **5b** would extend it to dns-driven
+(blacklist/whitelist precedence, SafeSearch/YouTube DNS) and squid-driven
+(egress default-deny, SSL-bump) settings — those need the backend to share the
+config volume with dns/proxy and a reload step.
 
 ## Roadmap (later phases, see #200)
 

--- a/tests/adversarial/attacker/Dockerfile
+++ b/tests/adversarial/attacker/Dockerfile
@@ -10,9 +10,10 @@ WORKDIR /adversarial
 # over these for fast iteration (edit corpus/driver, re-run, no rebuild).
 COPY attacker/attack.sh /adversarial/attack.sh
 COPY attacker/api-attack.sh /adversarial/api-attack.sh
+COPY attacker/config-matrix.sh /adversarial/config-matrix.sh
 COPY corpus.json /adversarial/corpus.json
 COPY api-corpus.json /adversarial/api-corpus.json
-RUN chmod +x /adversarial/attack.sh /adversarial/api-attack.sh
+RUN chmod +x /adversarial/attack.sh /adversarial/api-attack.sh /adversarial/config-matrix.sh
 
 # Default entrypoint runs plane 1 (block-matrix); run.sh also invokes the API
 # plane via `run --rm --entrypoint /adversarial/api-attack.sh`.

--- a/tests/adversarial/attacker/config-matrix.sh
+++ b/tests/adversarial/attacker/config-matrix.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Adversarial config-matrix (issue #200, harness Phase 5).
+#
+# Proves that changing a SETTING actually changes live proxy/WAF behaviour — not
+# just that the API accepts the change. It flips WAF rule-category toggles through
+# the REAL backend→WAF push path (POST /api/waf/categories/toggle → waf:8080)
+# and asserts the data plane flips:
+#   - disable a category  → that category's attack now PASSES through the proxy
+#   - a different category → still BLOCKS (the toggle is selective, not global)
+#   - re-enable            → the attack BLOCKS again
+#
+# Every probe uses a unique cache-buster query so neither Squid's cache nor the
+# WAF safe-cache can serve a stale verdict — the toggle's effect is observed
+# immediately (a category toggle also bumps the WAF ISTag, dropping Squid's
+# cached verdicts).
+#
+# Exit code = CI gate: non-zero if any expected flip did not happen.
+set -uo pipefail
+
+API="${API:-http://backend:5000}"
+PROXY="${PROXY:-http://proxy:3128}"
+BASE="${BASE:-http://upstream.test}"
+API_USER="${API_USER:-testadmin}"
+API_PASS="${API_PASS:-TestP@ss123!}"
+REPORT_DIR="${REPORT_DIR:-/report}"
+mkdir -p "$REPORT_DIR"
+
+green() { printf '\033[32m%s\033[0m' "$1"; }
+red()   { printf '\033[31m%s\033[0m' "$1"; }
+
+SQLI="/p?id=1%20UNION%20SELECT%20a%20FROM%20b"
+XSS="/p?q=%3Cscript%3Ealert(1)%3C%2Fscript%3E"
+
+cb=0
+# probe sends an attack payload through the proxy with a fresh cache-buster and
+# returns the HTTP status (403 = blocked). Retries briefly to absorb toggle
+# propagation timing.
+probe() {
+  local path=$1 want=$2 s
+  for _ in 1 2 3 4 5; do
+    cb=$((cb + 1))
+    s=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 12 --path-as-is \
+      -x "$PROXY" "${BASE}${path}&cb=${cb}" </dev/null 2>/dev/null)
+    [ "$s" = "$want" ] && break
+    sleep 1
+  done
+  echo "$s"
+}
+
+# toggleCat flips a WAF category through the backend mgmt API. Returns the HTTP
+# status of the backend call.
+toggleCat() {
+  local cat=$1 enabled=$2
+  curl -sS -o /dev/null -w '%{http_code}' --max-time 12 -u "$API_USER:$API_PASS" \
+    -X POST -H 'Content-Type: application/json' \
+    --data "{\"category\":\"${cat}\",\"enabled\":${enabled}}" \
+    "$API/api/waf/categories/toggle" </dev/null 2>/dev/null
+}
+
+REC=()
+rc=0
+add() { # name | detail | want-substring-of-verdict PASS/FAIL
+  REC+=("$1|$2|$3")
+  [ "$3" = "FAIL" ] && rc=1
+}
+check() { # name | got | wantExpr(0=pass) | detail
+  local name=$1 verdict=$2 detail=$3
+  add "$name" "$detail" "$verdict"
+}
+
+echo "── SPM adversarial config-matrix (WAF category toggles) ──────────────────"
+echo "   api=$API  proxy=$PROXY"
+echo
+
+# Baseline: both attacks blocked with default (all categories on).
+s=$(probe "$SQLI" 403); [ "$s" = 403 ] && v=PASS || v=FAIL
+check "baseline-sqli-blocked" "$v" "SQLi→$s (want 403)"
+s=$(probe "$XSS" 403); [ "$s" = 403 ] && v=PASS || v=FAIL
+check "baseline-xss-blocked" "$v" "XSS→$s (want 403)"
+
+# Disable SQL_INJECTION → SQLi passes, XSS still blocks (selective).
+t=$(toggleCat "SQL_INJECTION" false)
+[ "${t:0:1}" = 2 ] && v=PASS || v=FAIL
+check "toggle-off-sqli-api" "$v" "POST categories/toggle SQL_INJECTION=false → $t (want 2xx)"
+s=$(probe "$SQLI" 200); [ "$s" != 403 ] && v=PASS || v=FAIL
+check "sqli-disabled-passes" "$v" "category off: SQLi→$s (want NOT 403)"
+s=$(probe "$XSS" 403); [ "$s" = 403 ] && v=PASS || v=FAIL
+check "xss-still-blocks-while-sqli-off" "$v" "selective: XSS→$s (want 403)"
+
+# Re-enable SQL_INJECTION → SQLi blocks again.
+t=$(toggleCat "SQL_INJECTION" true)
+s=$(probe "$SQLI" 403); [ "$s" = 403 ] && v=PASS || v=FAIL
+check "sqli-reenabled-blocks" "$v" "re-enabled: SQLi→$s (want 403)"
+
+# Symmetric: disable XSS_ATTACKS → XSS passes, SQLi still blocks.
+t=$(toggleCat "XSS_ATTACKS" false)
+[ "${t:0:1}" = 2 ] && v=PASS || v=FAIL
+check "toggle-off-xss-api" "$v" "POST categories/toggle XSS_ATTACKS=false → $t (want 2xx)"
+s=$(probe "$XSS" 200); [ "$s" != 403 ] && v=PASS || v=FAIL
+check "xss-disabled-passes" "$v" "category off: XSS→$s (want NOT 403)"
+s=$(probe "$SQLI" 403); [ "$s" = 403 ] && v=PASS || v=FAIL
+check "sqli-still-blocks-while-xss-off" "$v" "selective: SQLi→$s (want 403)"
+
+# Restore (also the flip-back assertion).
+t=$(toggleCat "XSS_ATTACKS" true)
+s=$(probe "$XSS" 403); [ "$s" = 403 ] && v=PASS || v=FAIL
+check "xss-reenabled-blocks" "$v" "re-enabled: XSS→$s (want 403)"
+
+# ── Report ───────────────────────────────────────────────────────────────────
+{
+  echo "# Config-matrix report"
+  echo
+  echo "> Settings actually change live proxy/WAF behaviour — WAF category toggles"
+  echo "> flipped through the real backend→WAF push path (#200 Phase 5)."
+  echo
+  echo "| Check | Detail | Verdict |"
+  echo "|---|---|---|"
+  for r in "${REC[@]}"; do
+    printf '| %s | %s | %s |\n' "${r%%|*}" "$(echo "$r" | cut -d'|' -f2)" "${r##*|}"
+  done
+  echo
+  if [ "$rc" -eq 0 ]; then echo "_Gate: **PASS** — every toggle flipped the data plane as expected, selectively._"
+  else echo "_Gate: **FAIL** — a setting did not change proxy behaviour as expected._"; fi
+} >"$REPORT_DIR/config-matrix-report.md"
+
+echo
+for r in "${REC[@]}"; do
+  n=${r%%|*}; d=$(echo "$r" | cut -d'|' -f2); vv=${r##*|}
+  [ "$vv" = PASS ] && tag=$(green PASS) || tag=$(red FAIL)
+  printf '  %-34s %-46s %b\n' "$n" "$d" "$tag"
+done
+echo
+if [ "$rc" -eq 0 ]; then
+  echo "  gate: $(green PASS)"; echo "  report: $REPORT_DIR/config-matrix-report.md"; exit 0
+else
+  echo "  gate: $(red FAIL)"; echo "  report: $REPORT_DIR/config-matrix-report.md"; exit 1
+fi

--- a/tests/adversarial/docker-compose.adversarial.yml
+++ b/tests/adversarial/docker-compose.adversarial.yml
@@ -167,6 +167,8 @@ services:
   # Target for Phase 2 (API attacker): the attacker hits it DIRECTLY (not through
   # the proxy) to probe the app's own auth/authorization boundary. Known creds so
   # the driver can prove that legitimate access still works (control cases).
+  # Also on adv-internal + wired to the WAF mgmt API so Phase 5 (config-matrix)
+  # can flip WAF settings through the real backend→WAF push path.
   backend:
     build: ../../backend-go
     environment:
@@ -175,6 +177,10 @@ services:
       - SECRET_KEY=adv-e2e-secret-not-for-production
       - CORS_ALLOWED_ORIGINS=http://localhost:8011
       - DATABASE_PATH=/data/secure_proxy_adv.db
+      # WAF mgmt API (Phase 5): the WAF's creds, so backend→WAF pushes authenticate.
+      - WAF_URL=http://waf:8080
+      - WAF_SERVICE_USERNAME=adv
+      - WAF_SERVICE_PASSWORD=adv-not-a-real-secret
     volumes:
       - adv-backend-config:/config
       - adv-backend-data:/data
@@ -185,7 +191,8 @@ services:
       retries: 15
       start_period: 15s
     networks:
-      - adv-edge
+      - adv-edge      # reachable by the attacker directly
+      - adv-internal  # reach waf:8080 for the mgmt push (Phase 5)
     restart: "no"
 
   # ── Bench / latency (k6) ───────────────────────────────────────────────────
@@ -236,6 +243,7 @@ services:
       # no image rebuild.
       - ./attacker/attack.sh:/adversarial/attack.sh:ro
       - ./attacker/api-attack.sh:/adversarial/api-attack.sh:ro
+      - ./attacker/config-matrix.sh:/adversarial/config-matrix.sh:ro
       - ./corpus.json:/adversarial/corpus.json:ro
       - ./api-corpus.json:/adversarial/api-corpus.json:ro
       - ./report:/report

--- a/tests/adversarial/run.sh
+++ b/tests/adversarial/run.sh
@@ -38,7 +38,7 @@ mkdir -p report
 rm -f report/report.md report/report.json report/results.json \
       report/api-report.md report/api-report.json report/api-results.json \
       report/bench-report.md report/bench-baseline.json report/bench-proxied.json \
-      report/resilience-report.md
+      report/resilience-report.md report/config-matrix-report.md
 
 # Build the plane-3 bench report from k6's summary exports (baseline vs proxied),
 # reporting p50/p95/throughput and the proxy + ICAP overhead.
@@ -207,6 +207,12 @@ echo "── plane 3: bench/latency (k6 through proxy + WAF) ──"
   k6 run --quiet --summary-export=/report/bench-proxied.json /bench/bench.js; p3=$?
 bench_report
 
+# Plane 5 — config-matrix: settings actually change live proxy/WAF behaviour
+# (WAF category toggles through the real backend→WAF push path). Runs before the
+# disruptive resilience plane, at the healthy default config.
+echo "── plane 5: config-matrix (settings flip the data plane) ──"
+"${DC[@]}" run --rm --entrypoint /adversarial/config-matrix.sh attacker; p5=$?
+
 # Plane 4 — resilience (fail-closed + self-heal). Runs last: it disrupts the
 # data plane by stopping/starting waf and dns.
 echo "── plane 4: resilience (fail-closed + self-heal) ──"
@@ -216,9 +222,10 @@ resilience; p4=$P4_RC
 [ "$p2" -ne 0 ] && rc=1
 [ "$p3" -ne 0 ] && rc=1
 [ "$p4" -ne 0 ] && rc=1
+[ "$p5" -ne 0 ] && rc=1
 
 echo
-for f in report/report.md report/api-report.md report/bench-report.md report/resilience-report.md; do
+for f in report/report.md report/api-report.md report/bench-report.md report/config-matrix-report.md report/resilience-report.md; do
   if [ -f "$f" ]; then
     echo "════════════════════════════════════════════════════════════════════════"
     cat "$f"
@@ -230,6 +237,7 @@ echo
 printf '  plane 1 (block-matrix): %s\n' "$([ "$p1" -eq 0 ] && echo PASS || echo FAIL)"
 printf '  plane 2 (API attacker): %s\n' "$([ "$p2" -eq 0 ] && echo PASS || echo FAIL)"
 printf '  plane 3 (bench/latency): %s\n' "$([ "${p3:-1}" -eq 0 ] && echo PASS || echo FAIL)"
+printf '  plane 5 (config-matrix): %s\n' "$([ "${p5:-1}" -eq 0 ] && echo PASS || echo FAIL)"
 printf '  plane 4 (resilience): %s\n' "$([ "${p4:-1}" -eq 0 ] && echo PASS || echo FAIL)"
 if [ "$rc" -eq 0 ]; then
   echo "✅ adversarial gate: PASS"


### PR DESCRIPTION
## What

Closes the gap raised in review: **do we actually test that settings change proxy behaviour?** Adds **Plane 5 — config-matrix**, which flips WAF rule-category toggles through the **real backend→WAF push path** (`POST /api/waf/categories/toggle` → `waf:8080`) and asserts the **live data plane** flips — not just that the API accepts the change.

## Checks (10/10 green)

| Check | Asserts |
|---|---|
| `baseline-sqli-blocked` / `baseline-xss-blocked` | both blocked at default config (403) |
| `sqli-disabled-passes` | disable `SQL_INJECTION` → the SQLi payload now **passes** (not 403) |
| `xss-still-blocks-while-sqli-off` | `XSS_ATTACKS` still blocks → the toggle is **selective**, not a global off-switch |
| `sqli-reenabled-blocks` | re-enable → SQLi blocks again |
| …symmetric for `XSS_ATTACKS`… | disable→pass, `SQL_INJECTION` still blocks, re-enable→block |

## How

- **compose**: the `backend` joins `adv-internal` and gets `WAF_URL` + `WAF_SERVICE_*` creds, so the backend→WAF mgmt push authenticates and resolves (it was `adv-edge`-only).
- **`attacker/config-matrix.sh`**: each probe uses a unique **cache-buster** query so neither Squid's cache nor the WAF safe-cache serves a stale verdict (a category toggle also bumps the WAF **ISTag**, dropping Squid's cached verdicts) — the flip is observed immediately.
- **`run.sh`**: plane 5 runs before the disruptive resilience plane; the gate fails if any toggle doesn't take effect.

All **five planes** pass together locally.

## Scope

WAF **category** toggles today. A **5b** would extend to dns-driven settings (blacklist/whitelist precedence, SafeSearch/YouTube DNS override) and squid-driven settings (egress default-deny, SSL-bump), which need the backend to share the config volume with dns/proxy plus a reload step.

Part of #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)