### PR TITLE
docs+ci: SWG positioning, security section, animated demo, Docker Hub publish

### DIFF
--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -52,6 +52,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub is where people search for images (GHCR has little organic
+      # discovery). Mirror there too — but only when the credentials exist, so
+      # the release still works with just GHCR if they are not configured.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract version from tag
         id: version
         run: |
@@ -61,6 +72,25 @@ jobs:
             echo "version=latest" >> $GITHUB_OUTPUT
           fi
 
+      # Tag list: always GHCR; add Docker Hub tags only when DOCKERHUB_USERNAME is set.
+      - name: Compute image tags
+        id: tags
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          IMG: ${{ matrix.image }}
+          DH_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE_PREFIX}-${IMG}:${VERSION}"
+            echo "${IMAGE_PREFIX}-${IMG}:latest"
+            if [ -n "$DH_USER" ]; then
+              echo "docker.io/${DH_USER}/secure-proxy-manager-${IMG}:${VERSION}"
+              echo "docker.io/${DH_USER}/secure-proxy-manager-${IMG}:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push ${{ matrix.image }}
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -69,9 +99,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.IMAGE_PREFIX }}-${{ matrix.image }}:${{ steps.version.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-${{ matrix.image }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Busts the proxy image's apt layer every run so a cached layer can
@@ -97,4 +125,10 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
           IMAGE: ${{ env.IMAGE_PREFIX }}-${{ matrix.image }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+      - name: Sign the Docker Hub image (keyless)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.DOCKERHUB_USERNAME != '' }}
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/secure-proxy-manager-${{ matrix.image }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/README.md
+++ b/README.md
@@ -5,16 +5,24 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Images: GHCR · cosign-signed](https://img.shields.io/badge/images-GHCR%20%C2%B7%20cosign--signed-2496ED?logo=docker&logoColor=white)](https://github.com/fabriziosalmi/secure-proxy-manager/pkgs/container/secure-proxy-manager-proxy)
 [![Docs](https://img.shields.io/badge/docs-website-22c55e)](https://fabriziosalmi.github.io/secure-proxy-manager/)
+[![WAF: 21 categories · FN=0 gated](https://img.shields.io/badge/WAF-21%20categories%20%C2%B7%20FN%3D0%20gated-3ddc84)](#tested-like-an-attacker)
 
 📖 **Documentation:** <https://fabriziosalmi.github.io/secure-proxy-manager/>
 
-A self-hosted forward proxy with a web UI for filtering, inspecting, and logging
-outbound HTTP/HTTPS traffic on a network. It combines a Squid proxy, a custom
-WAF, a DNS sinkhole, and a management API into a single Docker Compose stack.
+A **self-hosted Secure Web Gateway (SWG)** — one controllable egress point for a
+home, lab, or small-office network. It combines a Squid forward proxy, a custom
+**WAF** (request/response inspection over ICAP), a **DNS sinkhole**, and a modern
+web UI + API into a single Docker Compose stack: the self-hosted counterpart to
+cloud SWGs like Zscaler / Cloudflare Gateway — with **no traffic leaving your
+network**.
 
-Use it to give a home, lab, or small-office network one controllable egress
-point: block domains and IPs, inspect requests against WAF rules, sinkhole
-malware/ad domains at the DNS layer, and see what every client is reaching.
+Block domains and IPs, enforce a default-deny egress allowlist, inspect requests
+against WAF rules, sinkhole malware/ad domains at the DNS layer, and see what
+every client is reaching.
+
+![Malicious requests blocked by the proxy + WAF, benign traffic allowed](docs/demo/adversarial-demo.svg)
+
+<sub>Malicious requests get **403**'d at the proxy by the WAF; benign traffic passes. Every category is verified with an adversarial test suite — see [Tested like an attacker](#tested-like-an-attacker).</sub>
 
 ![Dashboard](docs/screenshots/dashboard.png)
 
@@ -23,17 +31,20 @@ malware/ad domains at the DNS layer, and see what every client is reaching.
 Most self-hosted network tools cover one layer. SPM combines forward-proxy egress
 control, request inspection, and DNS sinkholing in a single stack:
 
-| Capability | Pi-hole / AdGuard | Nginx Proxy Manager | **Secure Proxy Manager** |
-|---|:---:|:---:|:---:|
-| DNS sinkhole (block at resolve time) | ✅ | — | ✅ |
-| Forward proxy (outbound egress control) | — | — | ✅ |
-| HTTP request/body inspection (WAF) | — | — | ✅ |
-| Default-deny egress allowlist | — | — | ✅ |
-| Reverse proxy / ingress | — | ✅ | — |
+| Capability | Pi-hole / AdGuard | Nginx Proxy Manager | Cloud SWG (Zscaler…) | **Secure Proxy Manager** |
+|---|:---:|:---:|:---:|:---:|
+| DNS sinkhole (block at resolve time) | ✅ | — | ✅ | ✅ |
+| Forward proxy (outbound egress control) | — | — | ✅ | ✅ |
+| HTTP request/body inspection (WAF) | — | — | ✅ | ✅ |
+| Default-deny egress allowlist | — | — | ✅ | ✅ |
+| Reverse proxy / ingress | — | ✅ | — | — |
+| **Self-hosted — traffic stays on your network** | ✅ | ✅ | — | ✅ |
+| **Free / no per-seat cost** | ✅ | ✅ | — | ✅ |
 
-Pi-hole/AdGuard block at the DNS layer and Nginx Proxy Manager is reverse-proxy
-*ingress*; SPM is the **outbound** counterpart — one controllable egress point
-with WAF inspection and DNS sinkholing combined.
+Pi-hole/AdGuard block only at the DNS layer; Nginx Proxy Manager is reverse-proxy
+*ingress*; cloud SWGs do all of this but as a paid SaaS your traffic flows
+through. SPM is the **self-hosted outbound** counterpart — one controllable
+egress point with WAF inspection and DNS sinkholing combined, on your own metal.
 
 ## What it is
 
@@ -253,6 +264,34 @@ token.
   benchmarks.
 - [CHANGELOG.md](CHANGELOG.md) - release history.
 
+## Tested like an attacker
+
+Most proxies and WAFs ship rules and hope. SPM has an **adversarial e2e harness**
+(`make adversarial`, gated in CI) that drives real attack traffic *through* the
+running proxy + WAF in an isolated sandbox and **fails the build on any
+regression**. Five planes:
+
+- **block-matrix** — SQLi / XSS / RCE / SSRF / traversal / secret-exfil / … across
+  the **21 WAF categories**: malicious → **403**, benign → allowed. Gate: **false
+  negatives = 0, false positives = 0**.
+- **API attacker** — auth-bypass, forged / tampered JWTs (incl. `alg=none`), login
+  SQL-injection, rate-limit probing → **no bypass** (401/403/429 as expected).
+- **bench / latency** — p50/p95 + proxy + ICAP overhead, with a regression gate.
+- **config-matrix** — flips a setting through the real API and proves the data
+  plane changes (disable a rule category → that attack now passes; re-enable →
+  blocked again, selectively).
+- **resilience** — kill the WAF and the proxy **fails closed** (no fail-open
+  hole); restart it and the stack **self-heals**.
+
+Run it yourself — it brings up the sandbox, attacks it, prints a block-matrix +
+FP/FN report, and tears down:
+
+```bash
+make adversarial
+```
+
+See [`tests/adversarial/`](tests/adversarial/).
+
 ## Security notes
 
 - The SSL-bump CA is generated per deployment at first boot and never committed;
@@ -269,6 +308,13 @@ token.
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Issues and pull requests are welcome.
+
+## Support
+
+SPM is MIT-licensed and free to self-host. If it's useful to you:
+
+- ⭐ **Star** the repo and [**sponsor**](https://github.com/sponsors/fabriziosalmi) to support development.
+- 🛠️ **Want it installed, hardened, or managed** for your network or organisation? Email **fabrizio.salmi@gmail.com**.
 
 ## License
 

--- a/docs/demo/adversarial-demo.svg
+++ b/docs/demo/adversarial-demo.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 470" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" role="img" aria-label="Terminal demo: attacker traffic blocked by the proxy + WAF, benign traffic allowed">
+  <style>
+    .bg      { fill:#0b1021; }
+    .chrome  { fill:#161b2e; }
+    .txt     { fill:#c9d1e4; font-size:16px; }
+    .cmd     { fill:#8ab4ff; font-size:16px; }
+    .dim     { fill:#6b7594; font-size:15px; }
+    .block   { fill:#ff6b6b; font-size:16px; font-weight:600; }
+    .ok      { fill:#3ddc84; font-size:16px; font-weight:600; }
+    .title   { fill:#e6edff; font-size:15px; font-weight:600; }
+    .foot    { fill:#8ab4ff; font-size:14px; }
+    g.line   { opacity:0; }
+    /* one shared 16s loop; each line reveals at its slot, holds, then resets */
+    .a1{animation:a1 16s infinite} @keyframes a1{0%,4%{opacity:0}6%,92%{opacity:1}100%{opacity:0}}
+    .a2{animation:a2 16s infinite} @keyframes a2{0%,10%{opacity:0}12%,92%{opacity:1}100%{opacity:0}}
+    .a3{animation:a3 16s infinite} @keyframes a3{0%,22%{opacity:0}24%,92%{opacity:1}100%{opacity:0}}
+    .a4{animation:a4 16s infinite} @keyframes a4{0%,28%{opacity:0}30%,92%{opacity:1}100%{opacity:0}}
+    .a5{animation:a5 16s infinite} @keyframes a5{0%,40%{opacity:0}42%,92%{opacity:1}100%{opacity:0}}
+    .a6{animation:a6 16s infinite} @keyframes a6{0%,46%{opacity:0}48%,92%{opacity:1}100%{opacity:0}}
+    .a7{animation:a7 16s infinite} @keyframes a7{0%,58%{opacity:0}60%,92%{opacity:1}100%{opacity:0}}
+    .a8{animation:a8 16s infinite} @keyframes a8{0%,64%{opacity:0}66%,92%{opacity:1}100%{opacity:0}}
+    .a9{animation:a9 16s infinite} @keyframes a9{0%,76%{opacity:0}78%,92%{opacity:1}100%{opacity:0}}
+    .cur{animation:blink 1s steps(1) infinite}@keyframes blink{50%{opacity:0}}
+  </style>
+
+  <rect class="bg" x="0" y="0" width="860" height="470" rx="12"/>
+  <rect class="chrome" x="0" y="0" width="860" height="34" rx="12"/>
+  <rect class="chrome" x="0" y="22" width="860" height="12"/>
+  <circle cx="20" cy="17" r="6" fill="#ff5f57"/>
+  <circle cx="40" cy="17" r="6" fill="#febc2e"/>
+  <circle cx="60" cy="17" r="6" fill="#28c840"/>
+  <text class="title" x="430" y="22" text-anchor="middle">make adversarial — attacker ▶ proxy + WAF/ICAP</text>
+
+  <g class="line a1"><text class="cmd" x="20" y="72">$ curl -x proxy:3128 "http://site/?id=1 UNION SELECT pwd FROM users"</text></g>
+  <g class="line a2"><text class="block" x="40" y="96">↳ 403 Forbidden — blocked by WAF · SQL_INJECTION</text></g>
+
+  <g class="line a3"><text class="cmd" x="20" y="132">$ curl -x proxy:3128 "http://site/?q=&lt;script&gt;alert(1)&lt;/script&gt;"</text></g>
+  <g class="line a4"><text class="block" x="40" y="156">↳ 403 Forbidden — blocked by WAF · XSS_ATTACKS</text></g>
+
+  <g class="line a5"><text class="cmd" x="20" y="192">$ curl -x proxy:3128 "http://site/latest/meta-data/  (169.254.169.254)"</text></g>
+  <g class="line a6"><text class="block" x="40" y="216">↳ 403 Forbidden — blocked by WAF · SSRF</text></g>
+
+  <g class="line a7"><text class="cmd" x="20" y="252">$ curl -x proxy:3128 "http://site/blog/how-to-cook-pasta"</text></g>
+  <g class="line a8"><text class="ok" x="40" y="276">↳ 200 OK — allowed (benign traffic passes)</text></g>
+
+  <g class="line a9">
+    <text class="dim" x="20" y="316">─────────────────────────────────────────────────────────────</text>
+    <text class="txt" x="20" y="344">block-matrix: <tspan class="ok">TP=23</tspan>  <tspan class="ok">TN=10</tspan>  <tspan class="ok">FN=0</tspan>  <tspan class="ok">FP=0</tspan>   ·   5 planes: block-matrix · API · bench · config · resilience</text>
+    <text class="foot" x="20" y="372">21 WAF categories · false-negatives gated to 0 on every commit · self-hosted, no data leaves your network</text>
+  </g>
+
+  <text class="cmd" x="20" y="420">$ <tspan class="cur">▋</tspan></text>
+</svg>


### PR DESCRIPTION
Shipping / discoverability pass (distribution — the actual bottleneck). Covers the agreed items **1, 2, 3, 4, 6**.

## README (items 3, 4, 6)
- **Positioning (4):** reframed as a **self-hosted Secure Web Gateway (SWG)** — the self-hosted counterpart to cloud SWGs (Zscaler / Cloudflare Gateway), *no traffic leaves your network*. Comparison table gains a **Cloud SWG (SaaS)** column + **self-hosted** / **no per-seat cost** rows.
- **Security / trust (3):** new **"Tested like an attacker"** section surfacing the 5-plane adversarial harness (block-matrix **FN=0/FP=0**, API attacker, bench, config-matrix, resilience) + a **`WAF: 21 categories · FN=0 gated`** badge. Nobody else in this space publishes provable WAF coverage.
- **Support (6):** soft monetization — sponsor + a discreet *"want it installed / hardened / managed? email"* lead line. `FUNDING.yml` already has the Sponsor button.

## Demo (item 2)
- `docs/demo/adversarial-demo.svg` — a self-contained **animated SVG** terminal: malicious requests (SQLi/XSS/SSRF) get **403**'d at the proxy by the WAF, benign traffic passes, footer shows `TP=23 TN=10 FN=0 FP=0`. Renders + animates on GitHub, embedded near the top.

## Docker Hub (item 1)
- `multi-arch.yml` now mirrors the signed multi-arch images to **Docker Hub** as well as GHCR — **fully gated on `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`**, so the release still works with just GHCR until those secrets are added.
- Also added discoverability **GitHub topics**: `waf`, `icap`, `dns-filtering`, `secure-web-gateway`, `self-hosted`, `egress-filtering`, `content-filtering`, `homelab`.

## Action needed from you
Add repo secrets **`DOCKERHUB_USERNAME`** and **`DOCKERHUB_TOKEN`** (Settings → Secrets → Actions) to activate the Docker Hub mirror on the next tag. Without them, nothing changes.

Docs/CI only — no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)