### PR TITLE
chore(release): v3.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.5] - 2026-08-02
+
+### Added
+
+- **Docker Hub images.** The signed multi-arch images are now mirrored to Docker
+  Hub alongside GHCR (gated on `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`), for
+  easier discovery and `docker pull`.
+- **Config-matrix plane** in the adversarial harness (Phase 5): flips a WAF
+  rule-category setting through the real backend→WAF path and asserts the live
+  data plane changes accordingly (a disabled category's attack passes; another
+  still blocks; re-enable blocks again). The `make adversarial` suite is now five
+  planes: block-matrix · API attacker · bench/latency · config-matrix · resilience.
+
+### Changed
+
+- **Docs / positioning.** README reframed as a **self-hosted Secure Web Gateway
+  (SWG)** with an expanded comparison table, a "Tested like an attacker" section
+  surfacing the adversarial harness (`WAF: 21 categories · FN=0 gated`), an
+  animated demo, and a Support section. No application-code changes in the docs
+  pass.
+
 ## [3.11.4] - 2026-08-02
 
 ### Added

--- a/backend-go/internal/config/version.go
+++ b/backend-go/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // AppVersion is the semantic version of this backend build.
-const AppVersion = "3.11.4"
+const AppVersion = "3.11.5"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secure-proxy-manager-ui",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secure-proxy-manager-ui",
-      "version": "3.11.4",
+      "version": "3.11.5",
       "dependencies": {
         "@tanstack/react-query": "^5.95.0",
         "axios": "^1.16.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "secure-proxy-manager-ui",
   "private": true,
-  "version": "3.11.4",
+  "version": "3.11.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch bump **3.11.4 → 3.11.5**.

Bundles the work merged since v3.11.4 + activates the Docker Hub image mirror (now that the DOCKERHUB secrets are set):
- **#209** — adversarial harness **config-matrix** plane (Phase 5): settings flip the live data plane.
- **#210** — Docker Hub image mirror, **self-hosted SWG** positioning, "Tested like an attacker" section, animated demo, Support section.

Version-sync verified (version.go / package.json / package-lock.json / CHANGELOG all `3.11.5`). Tagging `v3.11.5` will build + sign the multi-arch images and push them to **both GHCR and Docker Hub**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)