### PR TITLE
feat(mcp): MCP server to manage SPM from an AI agent (spm-mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,21 @@ make adversarial
 
 See [`tests/adversarial/`](tests/adversarial/).
 
+## Manage it from an AI agent (MCP)
+
+SPM ships an optional [Model Context Protocol](https://modelcontextprotocol.io)
+server ([`mcp/`](mcp/)) that exposes the management API as tools, so an assistant
+or agent (e.g. Claude) can **drive your Secure Web Gateway in natural language** —
+"what are my top egressing domains?", "is anything reaching AI APIs?", "block
+`evil.example`", "disable the SQL_INJECTION category for 5 minutes". Read tools
+are safe; mutating tools (block/toggle/reload) are explicit and approved per call.
+
+```bash
+SPM_URL=http://localhost:5001 SPM_USERNAME=admin SPM_PASSWORD=... uvx spm-mcp
+```
+
+See [`mcp/README.md`](mcp/README.md) for the tool list and Claude Desktop config.
+
 ## Security notes
 
 - The SSL-bump CA is generated per deployment at first boot and never committed;

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+dist/
+build/
+*.egg-info/
+.venv/

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,16 @@
+# spm-mcp — MCP server for Secure Proxy Manager.
+# Small image; runs the stdio MCP server. Point it at the SPM backend via env.
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY pyproject.toml README.md ./
+COPY spm_mcp ./spm_mcp
+
+RUN pip install --no-cache-dir .
+
+# Non-root.
+RUN useradd -u 1000 -m mcp
+USER mcp
+
+# stdio transport (MCP clients spawn and speak over stdio).
+ENTRYPOINT ["spm-mcp"]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,65 @@
+# spm-mcp — MCP server for Secure Proxy Manager
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes
+the [Secure Proxy Manager](https://github.com/fabriziosalmi/secure-proxy-manager)
+management API as tools — so an assistant/agent (e.g. Claude) can **inspect and
+drive your self-hosted Secure Web Gateway**: query traffic and analytics, manage
+block/allow lists, toggle WAF rule categories, and reload config.
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `spm_status`, `spm_dashboard` | health + summary totals |
+| `spm_top_domains`, `spm_shadow_it`, `spm_user_agents` | analytics (incl. shadow-IT / agent egress) |
+| `spm_recent_logs` | recent proxy access-log rows |
+| `spm_security_score` | posture score |
+| `spm_waf_categories`, `spm_list_domain_blocklist` | current WAF/list state |
+| `spm_block_domain`, `spm_unblock_domain` | **mutate** the domain blocklist |
+| `spm_toggle_waf_category` | **mutate** — enable/disable a WAF category at runtime |
+| `spm_allow_egress` | **mutate** — add to the egress allowlist |
+| `spm_reload_config` | **mutate** — apply pending changes |
+
+Read tools are safe; mutating tools change live proxy behaviour and are named
+with an explicit verb. Approve mutating tool calls deliberately.
+
+## Configure
+
+| Env | Default | Meaning |
+|---|---|---|
+| `SPM_URL` | `http://localhost:5001` | SPM backend API base URL |
+| `SPM_USERNAME` | `admin` | SPM admin user (Basic auth) |
+| `SPM_PASSWORD` | — | SPM admin password |
+| `SPM_VERIFY` | `true` | `false` to skip TLS verify for self-signed HTTPS |
+
+## Run
+
+With [uv](https://docs.astral.sh/uv/) (no install):
+
+```bash
+SPM_URL=http://localhost:5001 SPM_USERNAME=admin SPM_PASSWORD=... \
+  uvx --from . spm-mcp
+```
+
+Or in Claude Desktop / any MCP client — add to the MCP servers config:
+
+```json
+{
+  "mcpServers": {
+    "secure-proxy-manager": {
+      "command": "uvx",
+      "args": ["spm-mcp"],
+      "env": {
+        "SPM_URL": "http://localhost:5001",
+        "SPM_USERNAME": "admin",
+        "SPM_PASSWORD": "your-password"
+      }
+    }
+  }
+}
+```
+
+Or as a container (see `Dockerfile`) — an optional `mcp` service can be added to
+the stack's compose profile.
+
+MIT-licensed, part of Secure Proxy Manager.

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "spm-mcp"
+version = "0.1.0"
+description = "Model Context Protocol server for Secure Proxy Manager — manage the proxy + WAF + DNS stack from an AI assistant/agent."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Fabrizio Salmi" }]
+keywords = ["mcp", "model-context-protocol", "proxy", "waf", "secure-web-gateway", "self-hosted"]
+dependencies = [
+    "mcp>=2.0.0",
+    "httpx>=0.27",
+]
+
+[project.scripts]
+spm-mcp = "spm_mcp.server:main"
+
+[project.urls]
+Homepage = "https://github.com/fabriziosalmi/secure-proxy-manager"
+Repository = "https://github.com/fabriziosalmi/secure-proxy-manager"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["spm_mcp"]

--- a/mcp/spm_mcp/__init__.py
+++ b/mcp/spm_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""spm-mcp — MCP server for Secure Proxy Manager."""
+
+__version__ = "0.1.0"

--- a/mcp/spm_mcp/server.py
+++ b/mcp/spm_mcp/server.py
@@ -1,0 +1,153 @@
+"""spm-mcp — Model Context Protocol server for Secure Proxy Manager.
+
+Exposes the SPM management API as MCP tools so an assistant/agent (e.g. Claude)
+can inspect and drive the proxy + WAF + DNS stack: query traffic and analytics,
+manage block/allow lists, toggle WAF rule categories, and reload config.
+
+Configuration (env):
+  SPM_URL       Base URL of the SPM backend API (default http://localhost:5001)
+  SPM_USERNAME  Basic-auth username (the SPM admin user)
+  SPM_PASSWORD  Basic-auth password
+  SPM_VERIFY    "false" to skip TLS verification for self-signed HTTPS (default true)
+
+Read tools are safe. Mutating tools (block/unblock/toggle/allow/reload) change
+live proxy behaviour and are named with an explicit verb so the model — and the
+human approving tool calls — can tell them apart.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+from mcp.server import MCPServer
+
+SPM_URL = os.environ.get("SPM_URL", "http://localhost:5001").rstrip("/")
+SPM_USERNAME = os.environ.get("SPM_USERNAME", "admin")
+SPM_PASSWORD = os.environ.get("SPM_PASSWORD", "")
+SPM_VERIFY = os.environ.get("SPM_VERIFY", "true").lower() != "false"
+
+mcp = MCPServer("secure-proxy-manager")
+
+_client = httpx.Client(
+    base_url=SPM_URL,
+    auth=httpx.BasicAuth(SPM_USERNAME, SPM_PASSWORD),
+    verify=SPM_VERIFY,
+    timeout=20.0,
+    headers={"Accept": "application/json"},
+)
+
+
+def _req(method: str, path: str, **kw: Any) -> Any:
+    """Call the SPM API and return parsed JSON (or text), raising a readable error."""
+    try:
+        r = _client.request(method, path, **kw)
+    except httpx.HTTPError as e:  # network/DNS/TLS
+        return {"error": f"request failed: {e}", "hint": f"is SPM_URL={SPM_URL} reachable?"}
+    if r.status_code == 401:
+        return {"error": "unauthorized (401)", "hint": "check SPM_USERNAME / SPM_PASSWORD"}
+    if r.status_code >= 400:
+        return {"error": f"HTTP {r.status_code}", "body": r.text[:1000]}
+    ctype = r.headers.get("content-type", "")
+    return r.json() if "application/json" in ctype else r.text
+
+
+# ── Read / observe ───────────────────────────────────────────────────────────
+
+@mcp.tool()
+def spm_status() -> Any:
+    """Proxy/WAF status and version (health of the running stack)."""
+    return _req("GET", "/api/status")
+
+
+@mcp.tool()
+def spm_dashboard() -> Any:
+    """Dashboard summary: totals for requests, blocks, clients, top talkers."""
+    return _req("GET", "/api/dashboard/summary")
+
+
+@mcp.tool()
+def spm_top_domains(limit: int = 20) -> Any:
+    """Most-requested destination domains through the proxy."""
+    return _req("GET", "/api/analytics/top-domains", params={"limit": limit})
+
+
+@mcp.tool()
+def spm_shadow_it() -> Any:
+    """Shadow-IT view: apps/services clients reach that may be unsanctioned
+    (a good lens for shadow-AI / agent egress)."""
+    return _req("GET", "/api/analytics/shadow-it")
+
+
+@mcp.tool()
+def spm_user_agents() -> Any:
+    """Breakdown of client User-Agents seen egressing (browsers vs libraries/agents)."""
+    return _req("GET", "/api/analytics/user-agents")
+
+
+@mcp.tool()
+def spm_recent_logs(limit: int = 50) -> Any:
+    """Most recent proxy access-log rows (destination, status, client, blocked flag)."""
+    return _req("GET", "/api/logs", params={"limit": limit})
+
+
+@mcp.tool()
+def spm_security_score() -> Any:
+    """Composite security posture score for the deployment."""
+    return _req("GET", "/api/security/score")
+
+
+@mcp.tool()
+def spm_waf_categories() -> Any:
+    """List the WAF rule categories and whether each is enabled."""
+    return _req("GET", "/api/waf/categories")
+
+
+@mcp.tool()
+def spm_list_domain_blocklist() -> Any:
+    """The domain blocklist (domains sinkholed/denied at the proxy/DNS layer)."""
+    return _req("GET", "/api/domain-blacklist")
+
+
+# ── Mutate (changes live proxy behaviour) ────────────────────────────────────
+
+@mcp.tool()
+def spm_block_domain(domain: str) -> Any:
+    """BLOCK a domain (adds it to the domain blocklist). Changes live behaviour."""
+    return _req("POST", "/api/domain-blacklist", json={"domain": domain})
+
+
+@mcp.tool()
+def spm_unblock_domain(entry_id: int) -> Any:
+    """UNBLOCK a domain by its blocklist entry id (from spm_list_domain_blocklist)."""
+    return _req("DELETE", f"/api/domain-blacklist/{entry_id}")
+
+
+@mcp.tool()
+def spm_toggle_waf_category(category: str, enabled: bool) -> Any:
+    """ENABLE/DISABLE a WAF rule category at runtime (e.g. SQL_INJECTION, XSS_ATTACKS).
+    Disabling a category lets that attack class through — use with care."""
+    return _req("POST", "/api/waf/categories/toggle",
+                json={"category": category, "enabled": enabled})
+
+
+@mcp.tool()
+def spm_allow_egress(entry: str, description: str = "via mcp") -> Any:
+    """ALLOW a destination on the egress allowlist (relevant under default-deny egress)."""
+    return _req("POST", "/api/egress-allowlist",
+                json={"entry": entry, "description": description})
+
+
+@mcp.tool()
+def spm_reload_config() -> Any:
+    """Regenerate the proxy ACLs and signal a reload (apply pending list/setting changes)."""
+    return _req("POST", "/api/maintenance/reload-config", json={})
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds [`mcp/`](mcp/) — a **Model Context Protocol** server that exposes the SPM management API as tools, so an assistant/agent (e.g. Claude) can **drive your self-hosted Secure Web Gateway in natural language**. On-theme with the shadow-AI / agentic direction, and a strong differentiator: *MCP-native security proxy*.

## Tools (14)
- **read (safe):** `spm_status`, `spm_dashboard`, `spm_top_domains`, `spm_shadow_it`, `spm_user_agents`, `spm_recent_logs`, `spm_security_score`, `spm_waf_categories`, `spm_list_domain_blocklist`
- **mutate (explicit, per-call approval):** `spm_block_domain`, `spm_unblock_domain`, `spm_toggle_waf_category`, `spm_allow_egress`, `spm_reload_config`

Thin `httpx` client over the REST API (Basic auth via `SPM_URL` / `SPM_USERNAME` / `SPM_PASSWORD`). Runs via `uvx spm-mcp` or the included `Dockerfile`.

## Validated
Against **mcp 2.0** (`MCPServer` API): 14 tools register and map to the real endpoints and request shapes (e.g. `spm_block_domain` → `POST /api/domain-blacklist {"domain":…}`, `spm_toggle_waf_category` → `POST /api/waf/categories/toggle {"category":…,"enabled":…}`).

## Scope
Standalone optional component (Python) under `mcp/` — does not touch the Go/TS build. No overlap with `llmproxy` (that's an LLM *content* firewall; this is SPM *management*). A follow-up can add a CI lint/test job for it.

README gains a **"Manage it from an AI agent (MCP)"** section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)