### PR TITLE
docs(site): rebuild the VitePress landing to the SWG positioning

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: "Secure Proxy Manager"
-  text: "Containerised proxy management for homelabs and small networks"
-  tagline: A Squid forward proxy with a Go backend, React UI, and Go ICAP WAF — deployed in minutes with Docker Compose.
+  text: "Self-hosted Secure Web Gateway"
+  tagline: One controllable egress point for your network — Squid forward proxy + a real WAF (ICAP) + DNS sinkhole + a modern UI, in a single Docker Compose stack. The self-hosted counterpart to cloud SWGs, with no traffic leaving your network.
   image:
     src: /hero-icon.svg
     alt: Secure Proxy Manager
@@ -13,6 +13,9 @@ hero:
       text: Get Started
       link: /guide/getting-started
     - theme: alt
+      text: Tested like an attacker
+      link: /#tested-like-an-attacker
+    - theme: alt
       text: API Reference
       link: /api/reference
     - theme: alt
@@ -20,18 +23,69 @@ hero:
       link: https://github.com/fabriziosalmi/secure-proxy-manager
 
 features:
-  - title: Traffic filtering
-    details: Domain and IP blocking with CIDR and wildcard subdomain support. One-click import of curated public blocklists. Geo-based IP blocking by country code.
-  - title: Egress allowlist
-    details: Optional default-deny outbound egress. Turn SPM into a strict egress gateway where local clients reach only an explicit allowlist of IP/CIDR and domain destinations. Off by default; when off, behaviour is unchanged.
-  - title: IP whitelist
-    details: Whitelist trusted destination IPs to bypass the direct-IP block rule. Useful for LAN devices accessed by IP address.
-  - title: ICAP WAF
-    details: Go-based ICAP server inspects HTTP requests with 170 regex rules across 21 categories plus 7 behavioural heuristics. Anomaly scoring with a configurable block threshold.
-  - title: Real-time logs
-    details: Live log streaming over WebSocket with one-time token authentication. Filter, search, and aggregate access events.
-  - title: Hardened by default
-    details: HTTP Basic plus JWT authentication, login rate limiting, SSRF guard on import URLs, CORS allowlist, bcrypt password hashing, backend API bound to localhost only.
-  - title: Self-hosted
-    details: Runs entirely on your hardware via Docker Compose. SQLite database, no cloud dependency. Configurable via environment variables and the web UI.
+  - title: Forward-proxy egress control
+    details: One controllable egress point. Block domains and IPs (CIDR + wildcard), one-click import of curated blocklists, geo-based blocking, and an optional default-deny egress allowlist.
+  - title: Real WAF over ICAP
+    details: A Go ICAP service inspects requests/responses — ~170 rules across 21 categories + behavioural heuristics, anomaly scoring. False negatives gated to 0 by an adversarial suite on every commit.
+  - title: DNS sinkhole
+    details: dnsmasq sinkholes blacklisted / malware / ad domains at the network layer, before a connection is ever made. SafeSearch and YouTube-restricted enforcement included.
+  - title: MCP-native
+    details: Ships an optional Model Context Protocol server — inspect and drive the gateway from Claude or any agent in natural language ("what's reaching AI APIs?", "block evil.example").
+  - title: Real-time logs & analytics
+    details: Live log streaming over WebSocket, filter/search/aggregate, top-domains, shadow-IT, per-client views — and a correlation event-id linking a blocked request to its WAF event end-to-end.
+  - title: Hardened, signed, self-hosted
+    details: Basic + JWT auth, login rate-limit, SSRF guards, bcrypt, backend bound to localhost. Cosign-signed multi-arch images on GHCR + Docker Hub. Runs entirely on your hardware, SQLite, no cloud.
 ---
+
+## See it block
+
+![Malicious requests blocked by the proxy + WAF, benign traffic allowed](/demo/adversarial-demo.svg)
+
+Malicious requests get **403**'d at the proxy by the WAF; benign traffic passes.
+
+## How it compares
+
+| Capability | Pi-hole / AdGuard | Nginx Proxy Manager | Cloud SWG (Zscaler…) | **Secure Proxy Manager** |
+|---|:---:|:---:|:---:|:---:|
+| DNS sinkhole | ✅ | — | ✅ | ✅ |
+| Forward proxy (egress control) | — | — | ✅ | ✅ |
+| HTTP request/body inspection (WAF) | — | — | ✅ | ✅ |
+| Default-deny egress allowlist | — | — | ✅ | ✅ |
+| Reverse proxy / ingress | — | ✅ | — | — |
+| Self-hosted — traffic stays local | ✅ | ✅ | — | ✅ |
+| Free / no per-seat cost | ✅ | ✅ | — | ✅ |
+
+SPM is the **self-hosted outbound** counterpart to a cloud Secure Web Gateway —
+WAF inspection + DNS sinkholing + egress control, on your own metal.
+
+## Tested like an attacker
+
+An **adversarial e2e harness** (`make adversarial`, gated in CI) drives real
+attack traffic *through* the running proxy + WAF and fails the build on any
+regression — five planes:
+
+- **block-matrix** — SQLi / XSS / RCE / SSRF / … across 21 categories → **false negatives = 0**, benign → **false positives = 0**.
+- **API attacker** — auth-bypass, forged/tampered JWTs, login SQLi, rate-limit → no bypass.
+- **bench/latency** — p95 + ICAP overhead, regression-gated.
+- **config-matrix** — flip a setting → prove the data plane changes.
+- **resilience** — kill the WAF → the proxy **fails closed**, then self-heals.
+
+## Manage it from an agent (MCP)
+
+```bash
+SPM_URL=http://localhost:5001 SPM_USERNAME=admin SPM_PASSWORD=… uvx spm-mcp
+```
+
+Exposes the management API as MCP tools so an assistant/agent can query traffic,
+manage block/allow lists, toggle WAF categories, and reload config.
+
+## 30-second start
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/fabriziosalmi/secure-proxy-manager/main/deploy/install.sh | sudo bash
+```
+
+The installer checks Docker, generates random admin credentials, pulls the
+signed images, and starts the stack. Then point a client at the proxy on
+`:3128` and open the dashboard. See the [Getting Started](/guide/getting-started)
+guide.

--- a/docs/public/demo/adversarial-demo.svg
+++ b/docs/public/demo/adversarial-demo.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 470" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" role="img" aria-label="Terminal demo: attacker traffic blocked by the proxy + WAF, benign traffic allowed">
+  <style>
+    .bg      { fill:#0b1021; }
+    .chrome  { fill:#161b2e; }
+    .txt     { fill:#c9d1e4; font-size:16px; }
+    .cmd     { fill:#8ab4ff; font-size:16px; }
+    .dim     { fill:#6b7594; font-size:15px; }
+    .block   { fill:#ff6b6b; font-size:16px; font-weight:600; }
+    .ok      { fill:#3ddc84; font-size:16px; font-weight:600; }
+    .title   { fill:#e6edff; font-size:15px; font-weight:600; }
+    .foot    { fill:#8ab4ff; font-size:14px; }
+    g.line   { opacity:0; }
+    /* one shared 16s loop; each line reveals at its slot, holds, then resets */
+    .a1{animation:a1 16s infinite} @keyframes a1{0%,4%{opacity:0}6%,92%{opacity:1}100%{opacity:0}}
+    .a2{animation:a2 16s infinite} @keyframes a2{0%,10%{opacity:0}12%,92%{opacity:1}100%{opacity:0}}
+    .a3{animation:a3 16s infinite} @keyframes a3{0%,22%{opacity:0}24%,92%{opacity:1}100%{opacity:0}}
+    .a4{animation:a4 16s infinite} @keyframes a4{0%,28%{opacity:0}30%,92%{opacity:1}100%{opacity:0}}
+    .a5{animation:a5 16s infinite} @keyframes a5{0%,40%{opacity:0}42%,92%{opacity:1}100%{opacity:0}}
+    .a6{animation:a6 16s infinite} @keyframes a6{0%,46%{opacity:0}48%,92%{opacity:1}100%{opacity:0}}
+    .a7{animation:a7 16s infinite} @keyframes a7{0%,58%{opacity:0}60%,92%{opacity:1}100%{opacity:0}}
+    .a8{animation:a8 16s infinite} @keyframes a8{0%,64%{opacity:0}66%,92%{opacity:1}100%{opacity:0}}
+    .a9{animation:a9 16s infinite} @keyframes a9{0%,76%{opacity:0}78%,92%{opacity:1}100%{opacity:0}}
+    .cur{animation:blink 1s steps(1) infinite}@keyframes blink{50%{opacity:0}}
+  </style>
+
+  <rect class="bg" x="0" y="0" width="860" height="470" rx="12"/>
+  <rect class="chrome" x="0" y="0" width="860" height="34" rx="12"/>
+  <rect class="chrome" x="0" y="22" width="860" height="12"/>
+  <circle cx="20" cy="17" r="6" fill="#ff5f57"/>
+  <circle cx="40" cy="17" r="6" fill="#febc2e"/>
+  <circle cx="60" cy="17" r="6" fill="#28c840"/>
+  <text class="title" x="430" y="22" text-anchor="middle">make adversarial — attacker ▶ proxy + WAF/ICAP</text>
+
+  <g class="line a1"><text class="cmd" x="20" y="72">$ curl -x proxy:3128 "http://site/?id=1 UNION SELECT pwd FROM users"</text></g>
+  <g class="line a2"><text class="block" x="40" y="96">↳ 403 Forbidden — blocked by WAF · SQL_INJECTION</text></g>
+
+  <g class="line a3"><text class="cmd" x="20" y="132">$ curl -x proxy:3128 "http://site/?q=&lt;script&gt;alert(1)&lt;/script&gt;"</text></g>
+  <g class="line a4"><text class="block" x="40" y="156">↳ 403 Forbidden — blocked by WAF · XSS_ATTACKS</text></g>
+
+  <g class="line a5"><text class="cmd" x="20" y="192">$ curl -x proxy:3128 "http://site/latest/meta-data/  (169.254.169.254)"</text></g>
+  <g class="line a6"><text class="block" x="40" y="216">↳ 403 Forbidden — blocked by WAF · SSRF</text></g>
+
+  <g class="line a7"><text class="cmd" x="20" y="252">$ curl -x proxy:3128 "http://site/blog/how-to-cook-pasta"</text></g>
+  <g class="line a8"><text class="ok" x="40" y="276">↳ 200 OK — allowed (benign traffic passes)</text></g>
+
+  <g class="line a9">
+    <text class="dim" x="20" y="316">─────────────────────────────────────────────────────────────</text>
+    <text class="txt" x="20" y="344">block-matrix: <tspan class="ok">TP=23</tspan>  <tspan class="ok">TN=10</tspan>  <tspan class="ok">FN=0</tspan>  <tspan class="ok">FP=0</tspan>   ·   5 planes: block-matrix · API · bench · config · resilience</text>
+    <text class="foot" x="20" y="372">21 WAF categories · false-negatives gated to 0 on every commit · self-hosted, no data leaves your network</text>
+  </g>
+
+  <text class="cmd" x="20" y="420">$ <tspan class="cur">▋</tspan></text>
+</svg>


### PR DESCRIPTION
The docs site (https://fabriziosalmi.github.io/secure-proxy-manager/) led with generic copy and a default theme. Rebuilt the home page to match the README's positioning:

- **Hero:** "Self-hosted Secure Web Gateway" + the value prop (egress + WAF + DNS, no traffic leaves your network) + a *Tested like an attacker* CTA.
- **Feature grid** rewritten: forward-proxy egress control · real WAF over ICAP (FN=0 gated) · DNS sinkhole · MCP-native · real-time logs/analytics · hardened + signed images.
- **Below the fold:** the animated block demo, the comparison table (vs Pi-hole / NPM / Cloud SWG), the *Tested like an attacker* section, the MCP one-liner, and a 30-second start.

Builds clean (`vitepress build`). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)