### PR TITLE
docs(site): add Zion to the How it compares table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,18 +45,23 @@ Malicious requests get **403**'d at the proxy by the WAF; benign traffic passes.
 
 ## How it compares
 
-| Capability | Pi-hole / AdGuard | Nginx Proxy Manager | Cloud SWG (Zscaler…) | **Secure Proxy Manager** |
-|---|:---:|:---:|:---:|:---:|
-| DNS sinkhole | ✅ | — | ✅ | ✅ |
-| Forward proxy (egress control) | — | — | ✅ | ✅ |
-| HTTP request/body inspection (WAF) | — | — | ✅ | ✅ |
-| Default-deny egress allowlist | — | — | ✅ | ✅ |
-| Reverse proxy / ingress | — | ✅ | — | — |
-| Self-hosted — traffic stays local | ✅ | ✅ | — | ✅ |
-| Free / no per-seat cost | ✅ | ✅ | — | ✅ |
+| Capability | Pi-hole / AdGuard | Nginx Proxy Manager | Cloud SWG (Zscaler…) | [Zion](https://github.com/fabriziosalmi/zion) | **Secure Proxy Manager** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| DNS sinkhole | ✅ | — | ✅ | — | ✅ |
+| Forward proxy (egress control) | — | — | ✅ | — | ✅ |
+| HTTP request/body inspection (WAF) | — | — | ✅ | ✅ | ✅ |
+| Default-deny egress allowlist | — | — | ✅ | — | ✅ |
+| Reverse proxy / ingress | — | ✅ | — | ✅ | — |
+| Self-hosted — traffic stays local | ✅ | ✅ | — | ✅ | ✅ |
+| Free / no per-seat cost | ✅ | ✅ | — | ✅ | ✅ |
 
 SPM is the **self-hosted outbound** counterpart to a cloud Secure Web Gateway —
 WAF inspection + DNS sinkholing + egress control, on your own metal.
+
+Pair it with **[Zion](https://github.com/fabriziosalmi/zion)** — a single-binary
+Rust TLS **reverse** proxy with a built-in WAF — to cover the other direction:
+Zion inspects traffic coming **in**, SPM controls what goes **out**. Both
+self-hosted, both single-purpose, no cloud.
 
 ## Tested like an attacker
 


### PR DESCRIPTION
Adds a **Zion** column to the *How it compares* table on the docs landing page.

[Zion](https://github.com/fabriziosalmi/zion) is a single-binary Rust TLS **reverse** proxy with a built-in WAF — the **ingress** counterpart to SPM's **egress** SWG. Column values: ✅ WAF, ✅ reverse-proxy/ingress; — on DNS sinkhole / forward-proxy / egress-allowlist (out of scope for an ingress gateway); ✅ self-hosted; ✅ free/OSS (Apache-2.0).

Also adds a short "pair them" note framing the two as complementary — Zion guards what comes **in**, SPM controls what goes **out**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)