### PR TITLE
fix(readme): repair broken demo SVG image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Block domains and IPs, enforce a default-deny egress allowlist, inspect requests
 against WAF rules, sinkhole malware/ad domains at the DNS layer, and see what
 every client is reaching.
 
-![Malicious requests blocked by the proxy + WAF, benign traffic allowed](docs/demo/adversarial-demo.svg)
+![Malicious requests blocked by the proxy + WAF, benign traffic allowed](docs/public/demo/adversarial-demo.svg)
 
 <sub>Malicious requests get **403**'d at the proxy by the WAF; benign traffic passes. Every category is verified with an adversarial test suite — see [Tested like an attacker](#tested-like-an-attacker).</sub>
 


### PR DESCRIPTION
**Regression from #218.** That PR deleted `docs/demo/adversarial-demo.svg` believing it was an unused byte-identical duplicate — but `README.md` referenced it, so the demo image now 404s on github.com (and Docker Hub's README mirror). The docs **site** was unaffected because it serves the `docs/public/demo/` copy at `/demo/…`.

Fix: repoint README at the surviving file `docs/public/demo/adversarial-demo.svg`. Single source of truth, renders both on github.com (repo-relative path) and the site.

No version bump — README-only. `docs/index.md` already uses the correct `/demo/…` site path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)